### PR TITLE
Temporary fix for sizing option activation issue and replace tmp folder path to prevent crash 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,11 @@ jobs:
           poetry run pytest --no-cov src/fastga_he/models/propulsion/assemblies
         shell: bash
 
+      - name: Assembler unit tests
+        run: |
+          poetry run pytest --no-cov src/fastga_he/models/propulsion/assemblers
+        shell: bash
+
       - name: Mission unit tests
         run: |
           poetry run pytest --no-cov src/fastga_he/models/performances

--- a/integration_tests/cirrus_sr22/data/full_sizing_fuel.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_fuel.yml
@@ -19,12 +19,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   power_train_sizing:

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -15,13 +15,14 @@ from utils.filter_residuals import filter_residuals
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")
 
 
 @pytest.fixture(scope="module")
 def cleanup():
     """Empties results folder to avoid any conflicts."""
     rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    rmtree("D:/tmp", ignore_errors=True)
+    rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
 
 
 def test_sizing_sr22(cleanup):

--- a/integration_tests/daher_tbm900/data/ecopulse_new_wing.yml
+++ b/integration_tests/daher_tbm900/data/ecopulse_new_wing.yml
@@ -23,14 +23,14 @@ model:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicTurboprop
     wing_airfoil: naca63_415.af
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     use_openvsp: true
     compute_slipstream: false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicTurboprop
     wing_airfoil: naca63_415.af
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     use_openvsp: true
     compute_slipstream: false

--- a/integration_tests/daher_tbm900/data/full_sizing_tbm900.yml
+++ b/integration_tests/daher_tbm900/data/full_sizing_tbm900.yml
@@ -23,14 +23,14 @@ model:
             id: fastga.aerodynamics.lowspeed.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             wing_airfoil: naca63_415.af
-            result_folder_path: D:/tmp
+            result_folder_path: ../workdir
             use_openvsp: true
             compute_slipstream: true
         aerodynamics_highspeed:
             id: fastga.aerodynamics.highspeed.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             wing_airfoil: naca63_415.af
-            result_folder_path: D:/tmp
+            result_folder_path: ../workdir
             compute_mach_interpolation: false
             use_openvsp: true
             compute_slipstream: true

--- a/integration_tests/daher_tbm900/test_sizing_daher_tbm900.py
+++ b/integration_tests/daher_tbm900/test_sizing_daher_tbm900.py
@@ -23,13 +23,14 @@ from fastga_he.gui.power_train_weight_breakdown import power_train_mass_breakdow
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")
 
 
 @pytest.fixture(scope="module")
 def cleanup():
     """Empties results folder to avoid any conflicts."""
     rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    rmtree("D:/tmp", ignore_errors=True)
+    rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
 
 
 def test_sizing_tbm900():

--- a/integration_tests/oad_process/data/full_sizing_dep_ac.yml
+++ b/integration_tests/oad_process/data/full_sizing_dep_ac.yml
@@ -19,12 +19,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   performances:

--- a/integration_tests/oad_process/data/full_sizing_dep_ac_enforce.yml
+++ b/integration_tests/oad_process/data/full_sizing_dep_ac_enforce.yml
@@ -19,12 +19,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   performances:

--- a/integration_tests/oad_process/data/full_sizing_fuel_and_battery.yml
+++ b/integration_tests/oad_process/data/full_sizing_fuel_and_battery.yml
@@ -19,12 +19,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   power_train_sizing:

--- a/integration_tests/oad_process/data/full_sizing_fuel_and_battery_share.yml
+++ b/integration_tests/oad_process/data/full_sizing_fuel_and_battery_share.yml
@@ -19,12 +19,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   power_train_sizing:

--- a/integration_tests/oad_process/test_oad_process.py
+++ b/integration_tests/oad_process/test_oad_process.py
@@ -18,13 +18,14 @@ from utils.filter_residuals import filter_residuals
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")
 
 
 @pytest.fixture(scope="module")
 def cleanup():
     """Empties results folder to avoid any conflicts."""
     rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    rmtree("D:/tmp", ignore_errors=True)
+    rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
 
 
 def test_fuel_and_battery(cleanup):

--- a/integration_tests/pipistrel/data/pipistrel_configuration.yml
+++ b/integration_tests/pipistrel/data/pipistrel_configuration.yml
@@ -20,12 +20,12 @@ model:
   aerodynamics_lowspeed:
     id: fastga.aerodynamics.lowspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path : D:/tmp
+    result_folder_path : ../workdir
     compute_slipstream : false
   aerodynamics_highspeed:
     id: fastga.aerodynamics.highspeed.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-    result_folder_path: D:/tmp
+    result_folder_path: ../workdir
     compute_mach_interpolation: false
     compute_slipstream: false
   performances:

--- a/integration_tests/quest_kodiak100/data/full_sizing_kodiak100.yml
+++ b/integration_tests/quest_kodiak100/data/full_sizing_kodiak100.yml
@@ -22,12 +22,12 @@ model:
         aerodynamics_lowspeed:
             id: fastga.aerodynamics.lowspeed.legacy
             propulsion_id: fastga.wrapper.propulsion.basicTurboprop
-            result_folder_path: D:/tmp
+            result_folder_path: ../workdir
             use_openvsp: false
         aerodynamics_highspeed:
             id: fastga.aerodynamics.highspeed.legacy
             propulsion_id: fastga.wrapper.propulsion.basicTurboprop
-            result_folder_path: D:/tmp
+            result_folder_path: ../workdir
             compute_mach_interpolation: false
             use_openvsp: false
         power_train_sizing:

--- a/integration_tests/quest_kodiak100/test_sizing_quest_kodiak100.py
+++ b/integration_tests/quest_kodiak100/test_sizing_quest_kodiak100.py
@@ -15,13 +15,14 @@ from utils.filter_residuals import filter_residuals
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")
 
 
 @pytest.fixture(scope="module")
 def cleanup():
     """Empties results folder to avoid any conflicts."""
     rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    rmtree("D:/tmp", ignore_errors=True)
+    rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
 
 
 def test_sizing_kodiak_100():

--- a/src/fastga_he/models/environmental_impacts/lca.py
+++ b/src/fastga_he/models/environmental_impacts/lca.py
@@ -251,6 +251,7 @@ class LCA(om.Group):
             components_type,
             components_om_type,
             _,
+            _,
         ) = self.configurator.get_sizing_element_lists()
 
         for (

--- a/src/fastga_he/models/propulsion/assemblers/sizing_from_pt_file.py
+++ b/src/fastga_he/models/propulsion/assemblers/sizing_from_pt_file.py
@@ -44,6 +44,7 @@ class PowerTrainSizingFromFile(om.Group):
             components_name_id,
             components_type,
             components_om_type,
+            components_options,
             components_position,
         ) = self.configurator.get_sizing_element_lists()
 
@@ -52,16 +53,23 @@ class PowerTrainSizingFromFile(om.Group):
             component_name_id,
             component_type,
             component_om_type,
+            component_option,
             component_position,
         ) in zip(
             components_name,
             components_name_id,
             components_type,
             components_om_type,
+            components_options,
             components_position,
         ):
             local_sub_sys = he_comp.__dict__["Sizing" + component_om_type]()
             local_sub_sys.options[component_name_id] = component_name
+
+            if component_option:
+                for option_name in component_option:
+                    local_sub_sys.options[option_name] = component_option[option_name]
+
             if component_position:
                 local_sub_sys.options["position"] = component_position
 

--- a/src/fastga_he/models/propulsion/assemblers/unit_tests/test_assemblers.py
+++ b/src/fastga_he/models/propulsion/assemblers/unit_tests/test_assemblers.py
@@ -29,6 +29,7 @@ def test_clean_lift_wing():
         XML_FILE,
     )
     ivc.add_output("alpha", val=np.full(NB_POINTS_TEST, 5.0), units="deg")
+    ivc.add_output("altitude", val=np.full(NB_POINTS_TEST, 0.0), units="ft")
 
     # Run problem and check obtained value(s) is/(are) correct
     problem = run_system(

--- a/src/fastga_he/models/propulsion/assemblies/data/simple_sizing_option_test.yml
+++ b/src/fastga_he/models/propulsion/assemblies/data/simple_sizing_option_test.yml
@@ -1,0 +1,96 @@
+title: Sample power train file for testing hydrogen electric power train
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+  dc_sspc_2:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+  dc_sspc_412:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+  dc_bus_2:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+  dc_sspc_1337:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+  dc_dc_converter_1:
+    id: fastga_he.pt_component.dc_dc_converter
+  pemfc_stack_1:
+    id: fastga_he.pt_component.pemfc_stack
+    options:
+      model_fidelity: analytical
+  h2_fuel_system_1:
+    id: fastga_he.pt_component.h2_fuel_system
+    options:
+      number_of_tanks: 1
+      number_of_power_sources: 1
+      wing_related: False
+      compact: False
+    position: in_the_rear
+  gaseous_hydrogen_tank_1:
+    id: fastga_he.pt_component.gaseous_hydrogen_tank
+    position: in_the_cabin
+
+component_connections:
+  - source: propeller_1
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: [dc_bus_1, 1]
+
+  - source: [dc_bus_1, 1]
+    target: dc_sspc_2
+
+  - source: dc_sspc_2
+    target: harness_1
+
+  - source: harness_1
+    target: dc_sspc_412
+
+  - source: dc_sspc_412
+    target: [dc_bus_2, 1]
+
+  - source: [dc_bus_2, 1]
+    target: dc_sspc_1337
+
+  - source: dc_sspc_1337
+    target: dc_dc_converter_1
+
+  - source: dc_dc_converter_1
+    target: pemfc_stack_1
+
+  - source: pemfc_stack_1
+    target: [h2_fuel_system_1, 1]
+
+  - source: [h2_fuel_system_1, 1]
+    target: gaseous_hydrogen_tank_1
+
+watcher_file_path: ./simple_assembly_performances_gh2_pemfc.csv

--- a/src/fastga_he/models/propulsion/assemblies/data/simple_sizing_option_test.yml
+++ b/src/fastga_he/models/propulsion/assemblies/data/simple_sizing_option_test.yml
@@ -46,8 +46,8 @@ power_train_components:
     options:
       number_of_tanks: 1
       number_of_power_sources: 1
-      wing_related: False
-      compact: False
+      wing_related: True
+      compact: True
     position: in_the_rear
   gaseous_hydrogen_tank_1:
     id: fastga_he.pt_component.gaseous_hydrogen_tank

--- a/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
+++ b/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
@@ -689,7 +689,18 @@ def test_performances_sizing_from_pt_with_sizing_options():
     )
 
     problem.setup()
+    problem.run_model()
+
+    assert problem.get_val(
+        "data:propulsion:he_power_train:H2_fuel_system:h2_fuel_system_1:mass",
+        units="kg",
+    ) == pytest.approx(1.158, rel=1e-2)
+    assert problem.get_val(
+        "data:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area", units="cm**2"
+    ) == pytest.approx(500.0, rel=1e-2)
     assert problem.model.full.sizing.pemfc_stack_1.options["model_fidelity"] == "analytical"
+    assert problem.model.full.sizing.h2_fuel_system_1.options["wing_related"]
+    assert problem.model.full.sizing.h2_fuel_system_1.options["compact"]
 
 
 def test_cg_from_pt_file():

--- a/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
+++ b/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
@@ -642,11 +642,21 @@ def test_performances_sizing_assembly_pemfc_gh2_ensure_from_pt():
     assert problem.get_val(
         "data:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area", units="cm**2"
     ) == pytest.approx(2000.0, rel=1e-2)
+    assert problem.get_val(
+        "constraints:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area",
+        units="cm**2",
+    ) == pytest.approx(-1189.284, rel=1e-2)
 
 
 def test_performances_sizing_from_pt_with_sizing_options():
     oad.RegisterSubmodel.active_models["submodel.propulsion.constraints.pmsm.rpm"] = (
         "fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure"
+    )
+    oad.RegisterSubmodel.active_models[SUBMODEL_CONSTRAINTS_GASEOUS_HYDROGEN_TANK_CAPACITY] = (
+        "fastga_he.submodel.propulsion.constraints.gaseous_hydrogen_tank.capacity.ensure"
+    )
+    oad.RegisterSubmodel.active_models[SUBMODEL_CONSTRAINTS_PEMFC_EFFECTIVE_AREA] = (
+        "fastga_he.submodel.propulsion.constraints.pemfc_stack.effective_area.ensure"
     )
 
     pt_file_path = pth.join(DATA_FOLDER_PATH, "simple_sizing_option_test.yml")
@@ -696,8 +706,9 @@ def test_performances_sizing_from_pt_with_sizing_options():
         units="kg",
     ) == pytest.approx(1.158, rel=1e-2)
     assert problem.get_val(
-        "data:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area", units="cm**2"
-    ) == pytest.approx(500.0, rel=1e-2)
+        "constraints:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area",
+        units="cm**2",
+    ) == pytest.approx(-1727.809, rel=1e-2)
     assert problem.model.full.sizing.pemfc_stack_1.options["model_fidelity"] == "analytical"
     assert problem.model.full.sizing.h2_fuel_system_1.options["wing_related"]
     assert problem.model.full.sizing.h2_fuel_system_1.options["compact"]

--- a/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
+++ b/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
@@ -644,6 +644,54 @@ def test_performances_sizing_assembly_pemfc_gh2_ensure_from_pt():
     ) == pytest.approx(2000.0, rel=1e-2)
 
 
+def test_performances_sizing_from_pt_with_sizing_options():
+    oad.RegisterSubmodel.active_models["submodel.propulsion.constraints.pmsm.rpm"] = (
+        "fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure"
+    )
+
+    pt_file_path = pth.join(DATA_FOLDER_PATH, "simple_sizing_option_test.yml")
+
+    ivc = get_indep_var_comp(
+        list_inputs(
+            FullSimpleAssemblyPT(
+                power_train_file_path=pt_file_path,
+                number_of_points=NB_POINTS_TEST,
+                pre_condition_pt=True,
+            )
+        ),
+        __file__,
+        XML_FILE,
+    )
+
+    altitude = np.full(NB_POINTS_TEST, 0.0)
+    ivc.add_output("altitude", val=altitude, units="m")
+    ivc.add_output("density", val=Atmosphere(altitude).density, units="kg/m**3")
+    ivc.add_output("true_airspeed", val=np.linspace(81.8, 90.5, NB_POINTS_TEST), units="m/s")
+    ivc.add_output("thrust", val=np.linspace(1550, 1450, NB_POINTS_TEST), units="N")
+    ivc.add_output(
+        "exterior_temperature",
+        units="degK",
+        val=Atmosphere(altitude, altitude_in_feet=False).temperature,
+    )
+    ivc.add_output("time_step", units="s", val=np.full(NB_POINTS_TEST, 500))
+
+    problem = oad.FASTOADProblem(reports=False)
+    model = problem.model
+    model.add_subsystem(name="inputs", subsys=ivc, promotes=["*"])
+    model.add_subsystem(
+        name="full",
+        subsys=FullSimpleAssemblyPT(
+            power_train_file_path=pt_file_path,
+            number_of_points=NB_POINTS_TEST,
+            pre_condition_pt=True,
+        ),
+        promotes=["*"],
+    )
+
+    problem.setup()
+    assert problem.model.full.sizing.pemfc_stack_1.options["model_fidelity"] == "analytical"
+
+
 def test_cg_from_pt_file():
     pt_file_path = pth.join(DATA_FOLDER_PATH, "simple_assembly_gh2_pemfc.yml")
 

--- a/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
@@ -42,6 +42,22 @@ class SizingDCBus(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            name="number_of_inputs",
+            default=1,
+            types=int,
+            desc="Number of connections at the input of the bus",
+            allow_none=False,
+        )
+        self.options.declare(
+            name="number_of_outputs",
+            default=1,
+            types=int,
+            desc="Number of connections at the output of the bus",
+            allow_none=False,
+        )
+
     def setup(self):
         dc_bus_id = self.options["dc_bus_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
@@ -42,7 +42,7 @@ class SizingDCBus(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="number_of_inputs",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_bus/components/sizing_dc_bus.py
@@ -42,7 +42,7 @@ class SizingDCBus(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="number_of_inputs",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
@@ -41,6 +41,14 @@ class SizingDCSplitter(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            "splitter_mode",
+            default="percent_split",
+            desc="Mode of the power splitter, should be either percent_split or power_share",
+            values=["percent_split", "power_share"],
+        )
+
     def setup(self):
         position = self.options["position"]
         dc_splitter_id = self.options["dc_splitter_id"]

--- a/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
@@ -41,7 +41,7 @@ class SizingDCSplitter(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             "splitter_mode",
             default="percent_split",

--- a/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_splitter/components/sizing_dc_splitter.py
@@ -41,7 +41,7 @@ class SizingDCSplitter(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             "splitter_mode",
             default="percent_split",

--- a/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
@@ -38,7 +38,7 @@ class SizingDCSSPC(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             "closed",
             default=True,

--- a/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
@@ -38,7 +38,7 @@ class SizingDCSSPC(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             "closed",
             default=True,

--- a/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_sspc/components/sizing_dc_sspc.py
@@ -38,6 +38,20 @@ class SizingDCSSPC(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            "closed",
+            default=True,
+            desc="Boolean to choose whether the breaker is closed or not.",
+            types=bool,
+        )
+        self.options.declare(
+            "at_bus_output",
+            default=True,
+            desc="Boolean to inform whether the breaker is at the input or output of a bus.",
+            types=bool,
+        )
+
     def setup(self):
         dc_sspc_id = self.options["dc_sspc_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
@@ -35,7 +35,7 @@ class SizingFuelSystem(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="number_of_tanks",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
@@ -35,7 +35,7 @@ class SizingFuelSystem(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="number_of_tanks",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/sizing_fuel_system.py
@@ -35,6 +35,22 @@ class SizingFuelSystem(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            name="number_of_tanks",
+            default=1,
+            types=int,
+            desc="Number of connections at the input of the fuel system, should always be tanks",
+            allow_none=False,
+        )
+        self.options.declare(
+            name="number_of_engines",
+            default=1,
+            types=int,
+            desc="Number of connections at the output of the fuel system, should always be engine",
+            allow_none=False,
+        )
+
     def setup(self):
         fuel_system_id = self.options["fuel_system_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
@@ -41,7 +41,7 @@ class PerformancesH2FuelSystem(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="wing_related",
             default=False,

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
@@ -41,7 +41,7 @@ class PerformancesH2FuelSystem(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="wing_related",
             default=False,

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/perf_h2_fuel_system.py
@@ -40,6 +40,8 @@ class PerformancesH2FuelSystem(om.Group):
             desc="Number of connections at the output of the hydrogen fuel system",
             allow_none=False,
         )
+
+        # Dummy option to prevent error
         self.options.declare(
             name="wing_related",
             default=False,

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
@@ -52,7 +52,7 @@ class SizingH2FuelSystem(om.Group):
             desc="Option identifies weather the system is installed compactly in one position",
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="number_of_tanks",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
@@ -52,6 +52,22 @@ class SizingH2FuelSystem(om.Group):
             desc="Option identifies weather the system is installed compactly in one position",
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            name="number_of_tanks",
+            default=1,
+            types=int,
+            desc="Number of connections at the input of the hydrogen fuel system, should always be tanks",
+            allow_none=False,
+        )
+        self.options.declare(
+            name="number_of_power_sources",
+            default=1,
+            types=int,
+            desc="Number of connections at the output of the hydrogen fuel system",
+            allow_none=False,
+        )
+
     def setup(self):
         h2_fuel_system_id = self.options["h2_fuel_system_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/sizing_h2_fuel_system.py
@@ -52,7 +52,7 @@ class SizingH2FuelSystem(om.Group):
             desc="Option identifies weather the system is installed compactly in one position",
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="number_of_tanks",
             default=1,

--- a/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
+++ b/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
@@ -37,7 +37,7 @@ class SizingPlanetaryGear(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             "gear_mode",
             default="percent_split",

--- a/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
+++ b/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
@@ -37,7 +37,7 @@ class SizingPlanetaryGear(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             "gear_mode",
             default="percent_split",

--- a/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
+++ b/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/sizing_planetary_gear.py
@@ -37,6 +37,14 @@ class SizingPlanetaryGear(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            "gear_mode",
+            default="percent_split",
+            desc="Mode of the planetary gear, should be either percent_split or power_share",
+            values=["percent_split", "power_share"],
+        )
+
     def setup(self):
         position = self.options["position"]
         planetary_gear_id = self.options["planetary_gear_id"]

--- a/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
@@ -40,6 +40,15 @@ class SizingBatteryPack(om.Group):
             allow_none=False,
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            name="direct_bus_connection",
+            default=False,
+            types=bool,
+            desc="If the battery is directly connected to a bus, a special mode is required to "
+            "interface the two",
+        )
+
     def setup(self):
         battery_pack_id = self.options["battery_pack_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
@@ -40,7 +40,7 @@ class SizingBatteryPack(om.Group):
             allow_none=False,
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="direct_bus_connection",
             default=False,

--- a/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/sizing_battery_pack.py
@@ -40,7 +40,7 @@ class SizingBatteryPack(om.Group):
             allow_none=False,
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="direct_bus_connection",
             default=False,

--- a/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
@@ -42,7 +42,7 @@ class SizingPEMFCStack(om.Group):
             "Aerostak 200W empirical polarization model is set as default.",
         )
 
-        # The followong option(s) is/are dummy option(s) to prevent error
+        # The followong option(s) is/are dummy option(s) to ensure compatibility
         self.options.declare(
             name="direct_bus_connection",
             default=False,

--- a/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
@@ -42,6 +42,22 @@ class SizingPEMFCStack(om.Group):
             "Aerostak 200W empirical polarization model is set as default.",
         )
 
+        # Dummy option to prevent error
+        self.options.declare(
+            name="direct_bus_connection",
+            default=False,
+            types=bool,
+            desc="If the PEMFC stack is directly connected to a bus, a special mode is required to "
+            "interface the two",
+        )
+        self.options.declare(
+            name="compressor_connection",
+            default=False,
+            types=bool,
+            desc="The PEMFC stack operation pressure have to adjust based on compressor "
+            "connection for the oxygen/air inlet",
+        )
+
     def setup(self):
         pemfc_stack_id = self.options["pemfc_stack_id"]
         position = self.options["position"]

--- a/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/components/sizing_pemfc_stack.py
@@ -42,7 +42,7 @@ class SizingPEMFCStack(om.Group):
             "Aerostak 200W empirical polarization model is set as default.",
         )
 
-        # Dummy option to prevent error
+        # The followong option(s) is/are dummy option(s) to prevent error
         self.options.declare(
             name="direct_bus_connection",
             default=False,

--- a/src/fastga_he/powertrain_builder/powertrain.py
+++ b/src/fastga_he/powertrain_builder/powertrain.py
@@ -690,6 +690,7 @@ class FASTGAHEPowerTrainConfigurator:
             self._components_name_id,
             self._components_type,
             self._components_om_type,
+            self._components_options,
             self._components_position,
         )
 

--- a/src/fastga_he/powertrain_builder/unit_tests/test_power_train_file.py
+++ b/src/fastga_he/powertrain_builder/unit_tests/test_power_train_file.py
@@ -32,6 +32,7 @@ def test_power_train_file_components_sizing():
         components_name_id,
         components_type,
         components_om_type,
+        components_options,
         components_position,
     ) = power_train_configurator.get_sizing_element_lists()
 
@@ -40,6 +41,7 @@ def test_power_train_file_components_sizing():
     assert components_name_id
     assert components_type
     assert components_om_type
+    assert components_options
     assert components_position
 
 


### PR DESCRIPTION
The options in sizing groups, except for position, could not be properly activated via the PT file. With this temporary fix, the options that exist in or are specific to sizing are now accessible from the PT file, #75. The ```D:/tmp``` file paths are also replaced with ```workdir``` to prevent crash.  