### PR TITLE
Rework on energy needs and emission during assembly

### DIFF
--- a/docs/documentation/models/lca/assumptions.rst
+++ b/docs/documentation/models/lca/assumptions.rst
@@ -18,6 +18,11 @@ A nomenclature similar to that used in early drafts of the aircraft PEFCR has be
 
 Because of their relative simplicity and small contribution to the final impact, manufacturing and distribution have been assumed to be proportionate to the operation phase. Therefore, all their sub-processes have been aggregated, unlike the other phases for which a breakdown of contribution is available.
 
+Assumptions regarding assembly of components
+============================================
+
+While the impacts of most components is computed using proxies from the EcoInvent database, for the others, inventories were reconstructed from literature. Data for those reconstructed inventories should include the production of materials and other inputs required for the assembly of the components. For the former, data from :cite:`thonemann:2024` are used, and while data from the latter is also available it seems like the values given might already include the production of the materials. Consequently, and to avoid counting effect twice, for components with no proxies in the EcoInvent database, assembly will be discarded and only impacts from the production of materials will be considered.
+
 Other assumptions
 =================
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -450,3 +450,14 @@
   year={2018},
   publisher={John Wiley \& Sons}
 }
+
+@article{arvidsson:2024,
+  title={Life cycle assessment of a two-seater all-electric aircraft},
+  author={Arvidsson, Rickard and Nordel{\"o}f, Anders and Brynolf, Selma},
+  journal={The International Journal of Life Cycle Assessment},
+  volume={29},
+  number={2},
+  pages={240--254},
+  year={2024},
+  publisher={Springer}
+}

--- a/src/fastga_he/models/environmental_impacts/lca_flight_control_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_flight_control_weight_per_fu.py
@@ -10,6 +10,12 @@ class LCAFlightControlsWeightPerFU(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:weight:airframe:flight_controls:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+        self.add_input(
+            "data:environmental_impact:buy_to_fly:metallic",
+            val=1.0,
+            desc="Ratio of the amount of material purchased to the one that actually flies. "
+            "Typical value for metallic material is between 5 and 10",
+        )
 
         self.add_output("data:weight:airframe:flight_controls:mass_per_fu", val=1e-6, units="kg")
 
@@ -19,14 +25,28 @@ class LCAFlightControlsWeightPerFU(om.ExplicitComponent):
         outputs["data:weight:airframe:flight_controls:mass_per_fu"] = (
             inputs["data:weight:airframe:flight_controls:mass"]
             * inputs["data:environmental_impact:aircraft_per_fu"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         partials[
             "data:weight:airframe:flight_controls:mass_per_fu",
             "data:weight:airframe:flight_controls:mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = (
+            inputs["data:environmental_impact:aircraft_per_fu"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        )
         partials[
             "data:weight:airframe:flight_controls:mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs["data:weight:airframe:flight_controls:mass"]
+        ] = (
+            inputs["data:weight:airframe:flight_controls:mass"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        )
+        partials[
+            "data:weight:airframe:flight_controls:mass_per_fu",
+            "data:environmental_impact:buy_to_fly:metallic",
+        ] = (
+            inputs["data:weight:airframe:flight_controls:mass"]
+            * inputs["data:environmental_impact:aircraft_per_fu"]
+        )

--- a/src/fastga_he/models/environmental_impacts/lca_flight_control_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_flight_control_weight_per_fu.py
@@ -13,8 +13,8 @@ class LCAFlightControlsWeightPerFU(om.ExplicitComponent):
         self.add_input(
             "data:environmental_impact:buy_to_fly:metallic",
             val=1.0,
-            desc="Ratio of the amount of material purchased to the one that actually flies. "
-            "Typical value for metallic material is between 5 and 10",
+            desc="Ratio of the amount of material purchased to to what is really put into the "
+            "manufactured parts. Typical value for metallic material is between 5 and 10",
         )
 
         self.add_output("data:weight:airframe:flight_controls:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/lca_fuselage_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_fuselage_weight_per_fu.py
@@ -7,24 +7,76 @@ import openmdao.api as om
 
 
 class LCAFuselageWeightPerFU(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare(
+            name="airframe_material",
+            default="aluminium",
+            desc="Material used for the airframe which include wing, fuselage, HTP and VTP. LG will"
+            " always be in aluminium and flight controls in steel",
+            allow_none=False,
+            values=["aluminium", "composite"],
+        )
+
     def setup(self):
         self.add_input("data:weight:airframe:fuselage:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+
+        if self.options["airframe_material"] == "aluminium":
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:metallic",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for metallic material is between 5 and 10",
+            )
+        else:
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:composite",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for composite material is between 1 and 2",
+            )
 
         self.add_output("data:weight:airframe:fuselage:mass_per_fu", val=1e-6, units="kg")
 
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
         outputs["data:weight:airframe:fuselage:mass_per_fu"] = (
             inputs["data:weight:airframe:fuselage:mass"]
             * inputs["data:environmental_impact:aircraft_per_fu"]
+            * buy_to_fly
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+
+            partials[
+                "data:weight:airframe:fuselage:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:metallic",
+            ] = (
+                inputs["data:weight:airframe:fuselage:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
+            partials[
+                "data:weight:airframe:fuselage:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:composite",
+            ] = (
+                inputs["data:weight:airframe:fuselage:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+
         partials[
             "data:weight:airframe:fuselage:mass_per_fu", "data:weight:airframe:fuselage:mass"
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = inputs["data:environmental_impact:aircraft_per_fu"] * buy_to_fly
         partials[
             "data:weight:airframe:fuselage:mass_per_fu", "data:environmental_impact:aircraft_per_fu"
-        ] = inputs["data:weight:airframe:fuselage:mass"]
+        ] = inputs["data:weight:airframe:fuselage:mass"] * buy_to_fly

--- a/src/fastga_he/models/environmental_impacts/lca_fuselage_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_fuselage_weight_per_fu.py
@@ -25,15 +25,15 @@ class LCAFuselageWeightPerFU(om.ExplicitComponent):
             self.add_input(
                 "data:environmental_impact:buy_to_fly:metallic",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for metallic material is between 5 and 10",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for metallic material is between 5 and 10",
             )
         else:
             self.add_input(
                 "data:environmental_impact:buy_to_fly:composite",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for composite material is between 1 and 2",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for composite material is between 1 and 2",
             )
 
         self.add_output("data:weight:airframe:fuselage:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/lca_htp_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_htp_weight_per_fu.py
@@ -7,26 +7,78 @@ import openmdao.api as om
 
 
 class LCAHTPWeightPerFU(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare(
+            name="airframe_material",
+            default="aluminium",
+            desc="Material used for the airframe which include wing, fuselage, HTP and VTP. LG will"
+            " always be in aluminium and flight controls in steel",
+            allow_none=False,
+            values=["aluminium", "composite"],
+        )
+
     def setup(self):
         self.add_input("data:weight:airframe:horizontal_tail:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+
+        if self.options["airframe_material"] == "aluminium":
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:metallic",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for metallic material is between 5 and 10",
+            )
+        else:
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:composite",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for composite material is between 1 and 2",
+            )
 
         self.add_output("data:weight:airframe:horizontal_tail:mass_per_fu", val=1e-6, units="kg")
 
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
         outputs["data:weight:airframe:horizontal_tail:mass_per_fu"] = (
             inputs["data:weight:airframe:horizontal_tail:mass"]
             * inputs["data:environmental_impact:aircraft_per_fu"]
+            * buy_to_fly
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+
+            partials[
+                "data:weight:airframe:horizontal_tail:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:metallic",
+            ] = (
+                inputs["data:weight:airframe:horizontal_tail:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
+            partials[
+                "data:weight:airframe:horizontal_tail:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:composite",
+            ] = (
+                inputs["data:weight:airframe:horizontal_tail:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+
         partials[
             "data:weight:airframe:horizontal_tail:mass_per_fu",
             "data:weight:airframe:horizontal_tail:mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = inputs["data:environmental_impact:aircraft_per_fu"] * buy_to_fly
         partials[
             "data:weight:airframe:horizontal_tail:mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs["data:weight:airframe:horizontal_tail:mass"]
+        ] = inputs["data:weight:airframe:horizontal_tail:mass"] * buy_to_fly

--- a/src/fastga_he/models/environmental_impacts/lca_htp_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_htp_weight_per_fu.py
@@ -25,15 +25,15 @@ class LCAHTPWeightPerFU(om.ExplicitComponent):
             self.add_input(
                 "data:environmental_impact:buy_to_fly:metallic",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for metallic material is between 5 and 10",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for metallic material is between 5 and 10",
             )
         else:
             self.add_input(
                 "data:environmental_impact:buy_to_fly:composite",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for composite material is between 1 and 2",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for composite material is between 1 and 2",
             )
 
         self.add_output("data:weight:airframe:horizontal_tail:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/lca_landing_gear_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_landing_gear_weight_per_fu.py
@@ -11,6 +11,12 @@ class LCALandingGearWeightPerFU(om.ExplicitComponent):
         self.add_input("data:weight:airframe:landing_gear:main:mass", val=np.nan, units="kg")
         self.add_input("data:weight:airframe:landing_gear:front:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+        self.add_input(
+            "data:environmental_impact:buy_to_fly:metallic",
+            val=1.0,
+            desc="Ratio of the amount of material purchased to the one that actually flies. "
+            "Typical value for metallic material is between 5 and 10",
+        )
 
         self.add_output("data:weight:airframe:landing_gear:mass_per_fu", val=1e-6, units="kg")
 
@@ -18,23 +24,40 @@ class LCALandingGearWeightPerFU(om.ExplicitComponent):
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         outputs["data:weight:airframe:landing_gear:mass_per_fu"] = (
-            inputs["data:weight:airframe:landing_gear:main:mass"]
-            + inputs["data:weight:airframe:landing_gear:front:mass"]
-        ) * inputs["data:environmental_impact:aircraft_per_fu"]
+            (
+                inputs["data:weight:airframe:landing_gear:main:mass"]
+                + inputs["data:weight:airframe:landing_gear:front:mass"]
+            )
+            * inputs["data:environmental_impact:aircraft_per_fu"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         partials[
             "data:weight:airframe:landing_gear:mass_per_fu",
             "data:weight:airframe:landing_gear:main:mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = (
+            inputs["data:environmental_impact:aircraft_per_fu"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        )
         partials[
             "data:weight:airframe:landing_gear:mass_per_fu",
             "data:weight:airframe:landing_gear:front:mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = (
+            inputs["data:environmental_impact:aircraft_per_fu"]
+            * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        )
         partials[
             "data:weight:airframe:landing_gear:mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
         ] = (
             inputs["data:weight:airframe:landing_gear:main:mass"]
             + inputs["data:weight:airframe:landing_gear:front:mass"]
-        )
+        ) * inputs["data:environmental_impact:buy_to_fly:metallic"]
+        partials[
+            "data:weight:airframe:landing_gear:mass_per_fu",
+            "data:environmental_impact:buy_to_fly:metallic",
+        ] = (
+            inputs["data:weight:airframe:landing_gear:main:mass"]
+            + inputs["data:weight:airframe:landing_gear:front:mass"]
+        ) * inputs["data:environmental_impact:aircraft_per_fu"]

--- a/src/fastga_he/models/environmental_impacts/lca_landing_gear_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_landing_gear_weight_per_fu.py
@@ -14,8 +14,8 @@ class LCALandingGearWeightPerFU(om.ExplicitComponent):
         self.add_input(
             "data:environmental_impact:buy_to_fly:metallic",
             val=1.0,
-            desc="Ratio of the amount of material purchased to the one that actually flies. "
-            "Typical value for metallic material is between 5 and 10",
+            desc="Ratio of the amount of material purchased to to what is really put into the "
+            "manufactured parts. Typical value for metallic material is between 5 and 10",
         )
 
         self.add_output("data:weight:airframe:landing_gear:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/lca_vtp_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_vtp_weight_per_fu.py
@@ -7,26 +7,78 @@ import openmdao.api as om
 
 
 class LCAVTPWeightPerFU(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare(
+            name="airframe_material",
+            default="aluminium",
+            desc="Material used for the airframe which include wing, fuselage, HTP and VTP. LG will"
+            " always be in aluminium and flight controls in steel",
+            allow_none=False,
+            values=["aluminium", "composite"],
+        )
+
     def setup(self):
         self.add_input("data:weight:airframe:vertical_tail:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+
+        if self.options["airframe_material"] == "aluminium":
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:metallic",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for metallic material is between 5 and 10",
+            )
+        else:
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:composite",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for composite material is between 1 and 2",
+            )
 
         self.add_output("data:weight:airframe:vertical_tail:mass_per_fu", val=1e-6, units="kg")
 
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
         outputs["data:weight:airframe:vertical_tail:mass_per_fu"] = (
             inputs["data:weight:airframe:vertical_tail:mass"]
             * inputs["data:environmental_impact:aircraft_per_fu"]
+            * buy_to_fly
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+
+            partials[
+                "data:weight:airframe:vertical_tail:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:metallic",
+            ] = (
+                inputs["data:weight:airframe:vertical_tail:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
+            partials[
+                "data:weight:airframe:vertical_tail:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:composite",
+            ] = (
+                inputs["data:weight:airframe:vertical_tail:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+
         partials[
             "data:weight:airframe:vertical_tail:mass_per_fu",
             "data:weight:airframe:vertical_tail:mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"]
+        ] = inputs["data:environmental_impact:aircraft_per_fu"] * buy_to_fly
         partials[
             "data:weight:airframe:vertical_tail:mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs["data:weight:airframe:vertical_tail:mass"]
+        ] = inputs["data:weight:airframe:vertical_tail:mass"] * buy_to_fly

--- a/src/fastga_he/models/environmental_impacts/lca_vtp_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_vtp_weight_per_fu.py
@@ -25,15 +25,15 @@ class LCAVTPWeightPerFU(om.ExplicitComponent):
             self.add_input(
                 "data:environmental_impact:buy_to_fly:metallic",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for metallic material is between 5 and 10",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for metallic material is between 5 and 10",
             )
         else:
             self.add_input(
                 "data:environmental_impact:buy_to_fly:composite",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for composite material is between 1 and 2",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for composite material is between 1 and 2",
             )
 
         self.add_output("data:weight:airframe:vertical_tail:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/lca_wing_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_wing_weight_per_fu.py
@@ -7,24 +7,76 @@ import openmdao.api as om
 
 
 class LCAWingWeightPerFU(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare(
+            name="airframe_material",
+            default="aluminium",
+            desc="Material used for the airframe which include wing, fuselage, HTP and VTP. LG will"
+            " always be in aluminium and flight controls in steel",
+            allow_none=False,
+            values=["aluminium", "composite"],
+        )
+
     def setup(self):
         self.add_input("data:weight:airframe:wing:mass", val=np.nan, units="kg")
         self.add_input("data:environmental_impact:aircraft_per_fu", val=np.nan)
+
+        if self.options["airframe_material"] == "aluminium":
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:metallic",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for metallic material is between 5 and 10",
+            )
+        else:
+            self.add_input(
+                "data:environmental_impact:buy_to_fly:composite",
+                val=1.0,
+                desc="Ratio of the amount of material purchased to the one that actually flies. "
+                "Typical value for composite material is between 1 and 2",
+            )
 
         self.add_output("data:weight:airframe:wing:mass_per_fu", val=1e-6, units="kg")
 
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
         outputs["data:weight:airframe:wing:mass_per_fu"] = (
             inputs["data:weight:airframe:wing:mass"]
             * inputs["data:environmental_impact:aircraft_per_fu"]
+            * buy_to_fly
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        if self.options["airframe_material"] == "aluminium":
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:metallic"]
+
+            partials[
+                "data:weight:airframe:wing:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:metallic",
+            ] = (
+                inputs["data:weight:airframe:wing:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+        else:
+            buy_to_fly = inputs["data:environmental_impact:buy_to_fly:composite"]
+
+            partials[
+                "data:weight:airframe:wing:mass_per_fu",
+                "data:environmental_impact:buy_to_fly:composite",
+            ] = (
+                inputs["data:weight:airframe:wing:mass"]
+                * inputs["data:environmental_impact:aircraft_per_fu"]
+            )
+
         partials["data:weight:airframe:wing:mass_per_fu", "data:weight:airframe:wing:mass"] = (
-            inputs["data:environmental_impact:aircraft_per_fu"]
+            inputs["data:environmental_impact:aircraft_per_fu"] * buy_to_fly
         )
         partials[
             "data:weight:airframe:wing:mass_per_fu", "data:environmental_impact:aircraft_per_fu"
-        ] = inputs["data:weight:airframe:wing:mass"]
+        ] = inputs["data:weight:airframe:wing:mass"] * buy_to_fly

--- a/src/fastga_he/models/environmental_impacts/lca_wing_weight_per_fu.py
+++ b/src/fastga_he/models/environmental_impacts/lca_wing_weight_per_fu.py
@@ -25,15 +25,15 @@ class LCAWingWeightPerFU(om.ExplicitComponent):
             self.add_input(
                 "data:environmental_impact:buy_to_fly:metallic",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for metallic material is between 5 and 10",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for metallic material is between 5 and 10",
             )
         else:
             self.add_input(
                 "data:environmental_impact:buy_to_fly:composite",
                 val=1.0,
-                desc="Ratio of the amount of material purchased to the one that actually flies. "
-                "Typical value for composite material is between 1 and 2",
+                desc="Ratio of the amount of material purchased to to what is really put into the "
+                "manufactured parts. Typical value for composite material is between 1 and 2",
             )
 
         self.add_output("data:weight:airframe:wing:mass_per_fu", val=1e-6, units="kg")

--- a/src/fastga_he/models/environmental_impacts/resources/lca_conf_airframe.yml
+++ b/src/fastga_he/models/environmental_impacts/resources/lca_conf_airframe.yml
@@ -56,68 +56,17 @@ assembly:  # Airframe assembly, assumed to be the same as aircraft assembly give
       unit: kilogram
 
       assembly:
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
+        # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+        # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+        # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+        # of the things except electricity can be discarded.
         electricity:
           name: 'market group for electricity, high voltage'
           loc: 'RER'
-          amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene:
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 537530 / 5485.0 # In kg
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-          amount: 499.135 / 5485.0
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 89954.38395 / 5485.0 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 2.24067735 / 5485.0
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 35.53361811 / 5485.0
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
+          amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
 
         VOC:
-          amount: 168.2270343 / 5485.0
+          amount: 0.0049
           name: 'VOC, volatile organic compounds'
           categories:
             - 'air'

--- a/src/fastga_he/models/environmental_impacts/resources/lca_conf_airframe.yml
+++ b/src/fastga_he/models/environmental_impacts/resources/lca_conf_airframe.yml
@@ -61,7 +61,7 @@ assembly:  # Airframe assembly, assumed to be the same as aircraft assembly give
         electricity:
           name: 'market group for electricity, high voltage'
           loc: 'RER'
-          amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
+          amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
 
         gas:
           name: 'natural gas, burned in gas turbine'  # Not sure about this one

--- a/src/fastga_he/models/environmental_impacts/unit_tests/data/hybrid_propulsion_lca.yml
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/data/hybrid_propulsion_lca.yml
@@ -68,68 +68,17 @@ model:
               unit: kilogram
         
               assembly:
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
+                # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+                # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+                # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+                # of the things except electricity can be discarded.
                 electricity:
                   name: 'market group for electricity, high voltage'
                   loc: 'RER'
-                  amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene:
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 537530 / 5485.0 # In kg
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-                  amount: 499.135 / 5485.0
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 89954.38395 / 5485.0 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 2.24067735 / 5485.0
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 35.53361811 / 5485.0
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
+                  amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
         
                 VOC:
-                  amount: 168.2270343 / 5485.0
+                  amount: 0.0049
                   name: 'VOC, volatile organic compounds'
                   categories:
                     - 'air'
@@ -152,72 +101,10 @@ model:
                   name: 'market for aluminium, cast alloy'
                   amount: 1.0 - data__propulsion__he_power_train__propeller__propeller_1__material
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 13436 / 333.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1677 / 333.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 30 / 333.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 13889 / 333.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.149 / 333.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 2.356 / 333.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 11.154 / 333.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # propeller, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # propeller, resulting in an underestimation.
         planetary_gear_1:
             custom_attributes:
                 - attribute: "component"
@@ -237,72 +124,10 @@ model:
                   loc: 'GLO'
                   amount: 0.250
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 4516 / 112.8 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 4541 / 112.8 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 567 / 112.8 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 1202 / 112.8 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 2461 / 112.8 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 11000 / 112.8 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 10 / 112.8
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 4695 / 112.8 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.05 / 112.8
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.796 / 112.8
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 3.770 / 112.8
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the gearbox,
+                # but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # gearbox, resulting in an underestimation.
         motor_1:
             custom_attributes:
                 - attribute: "component"
@@ -363,72 +188,10 @@ model:
                   loc: 'GLO'
                   amount: 0.250
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 4516 / 112.8 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 4541 / 112.8 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 567 / 112.8 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 1202 / 112.8 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 2461 / 112.8 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 11000 / 112.8 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 10 / 112.8
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 4695 / 112.8 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.05 / 112.8
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.796 / 112.8
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 3.770 / 112.8
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the gearbox,
+                # but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # gearbox, resulting in an underestimation.
         turboshaft_1:
             custom_attributes:
                 - attribute: "component"
@@ -463,71 +226,10 @@ model:
                   name: 'market for aluminium alloy, metal matrix composite'
                   amount: 0.483
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 9484 / 237 # We are giving here the amount for 1 kg of turboshaft since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 9537 / 237 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1190 / 237 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 2524 / 237 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 5168 / 237 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 23000 / 237 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 22 / 237
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 9858 / 237 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.105 / 237
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 3.030 / 237
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 14.347 / 237
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # turboshaft, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # turboshaft, resulting in an underestimation.
 
         fuel_system_1:
             custom_attributes:
@@ -548,71 +250,10 @@ model:
                   loc: 'GLO'
                   amount: 0.333
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 918 / 22.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 923 / 22.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 115 / 22.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 244 / 22.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 500 / 22.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 2000 / 22.9  # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 2 / 22.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 954 / 22.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.01 / 22.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.162 / 22.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 0.766 / 22.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the fuel
+                # system, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't count the assembly of the fuel
+                # system, resulting in an underestimation.
 
 
     manufacturing:

--- a/src/fastga_he/models/environmental_impacts/unit_tests/data/pipistrel_assembly_lca.yml
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/data/pipistrel_assembly_lca.yml
@@ -68,68 +68,17 @@ model:
               unit: kilogram
         
               assembly:
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
+                # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+                # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+                # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+                # of the things except electricity can be discarded.
                 electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene:
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 537530 / 5485.0 # In kg
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-                  amount: 499.135 / 5485.0
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 89954.38395 / 5485.0 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 2.24067735 / 5485.0
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 35.53361811 / 5485.0
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
+                  name: 'electricity, high voltage, production mix'
+                  loc: 'FR'
+                  amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
         
                 VOC:
-                  amount: 168.2270343 / 5485.0
+                  amount: 0.0049
                   name: 'VOC, volatile organic compounds'
                   categories:
                     - 'air'
@@ -152,72 +101,10 @@ model:
                   name: 'market for aluminium, cast alloy'
                   amount: 1.0 - data__propulsion__he_power_train__propeller__propeller_1__material
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 13436 / 333.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1677 / 333.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 30 / 333.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 13889 / 333.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.149 / 333.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 2.356 / 333.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 11.154 / 333.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # propeller, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # propeller, resulting in an underestimation.
         motor_1:
             custom_attributes:
                 - attribute: "component"
@@ -392,8 +279,8 @@ model:
 
         electricity_for_mission_production:
         
-            name: 'market group for electricity, high voltage'
-            loc: 'RER'
+            name: 'electricity, high voltage, production mix'
+            loc: 'FR'
             # This variable should always exist since we will only add this part to the conf file if
             # there are batteries and if there are batteries the component that computes this value will be added
             amount: data__LCA__manufacturing__he_power_train__electricity__energy_per_fu / 1000
@@ -516,8 +403,8 @@ model:
                 - attribute: "component"
                   value: electricity_for_mission_operation
         
-            name: 'market group for electricity, high voltage'
-            loc: 'RER'
+            name: 'electricity, high voltage, production mix'
+            loc: 'FR'
             # This variable should always exist since we will only add this part to the conf file if
             # there are batteries and if there are batteries the component that computes this value will be added
             amount: data__LCA__operation__he_power_train__electricity__energy_per_fu / 1000

--- a/src/fastga_he/models/environmental_impacts/unit_tests/data/sr22_propulsion_lca.yml
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/data/sr22_propulsion_lca.yml
@@ -68,68 +68,17 @@ model:
               unit: kilogram
         
               assembly:
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
+                # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+                # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+                # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+                # of the things except electricity can be discarded.
                 electricity:
                   name: 'market group for electricity, high voltage'
                   loc: 'RER'
-                  amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene:
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 537530 / 5485.0 # In kg
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-                  amount: 499.135 / 5485.0
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 89954.38395 / 5485.0 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 2.24067735 / 5485.0
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 35.53361811 / 5485.0
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
+                  amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
         
                 VOC:
-                  amount: 168.2270343 / 5485.0
+                  amount: 0.0049
                   name: 'VOC, volatile organic compounds'
                   categories:
                     - 'air'
@@ -152,72 +101,10 @@ model:
                   name: 'market for aluminium, cast alloy'
                   amount: 1.0 - data__propulsion__he_power_train__propeller__propeller_1__material
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 13436 / 333.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1677 / 333.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 30 / 333.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 13889 / 333.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.149 / 333.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 2.356 / 333.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 11.154 / 333.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # propeller, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # propeller, resulting in an underestimation.
         ice_1:
             custom_attributes:
                 - attribute: "component"
@@ -246,71 +133,10 @@ model:
                   loc: 'GLO'
                   amount: 0.333
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 918 / 22.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 923 / 22.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 115 / 22.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 244 / 22.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 500 / 22.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 2000 / 22.9  # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 2 / 22.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 954 / 22.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.01 / 22.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.162 / 22.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 0.766 / 22.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the fuel
+                # system, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't count the assembly of the fuel
+                # system, resulting in an underestimation.
 
 
     manufacturing:

--- a/src/fastga_he/models/environmental_impacts/unit_tests/data/tbm900_propulsion_lca.yml
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/data/tbm900_propulsion_lca.yml
@@ -68,68 +68,17 @@ model:
               unit: kilogram
         
               assembly:
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
+                # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+                # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+                # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+                # of the things except electricity can be discarded.
                 electricity:
                   name: 'market group for electricity, high voltage'
                   loc: 'RER'
-                  amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene:
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 537530 / 5485.0 # In kg
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-                  amount: 499.135 / 5485.0
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 89954.38395 / 5485.0 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 2.24067735 / 5485.0
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 35.53361811 / 5485.0
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
+                  amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
         
                 VOC:
-                  amount: 168.2270343 / 5485.0
+                  amount: 0.0049
                   name: 'VOC, volatile organic compounds'
                   categories:
                     - 'air'
@@ -152,72 +101,10 @@ model:
                   name: 'market for aluminium, cast alloy'
                   amount: 1.0 - data__propulsion__he_power_train__propeller__propeller_1__material
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 13436 / 333.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1677 / 333.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 30 / 333.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 13889 / 333.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.149 / 333.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 2.356 / 333.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 11.154 / 333.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # propeller, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # propeller, resulting in an underestimation.
         turboshaft_1:
             custom_attributes:
                 - attribute: "component"
@@ -252,71 +139,10 @@ model:
                   name: 'market for aluminium alloy, metal matrix composite'
                   amount: 0.483
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 9484 / 237 # We are giving here the amount for 1 kg of turboshaft since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 9537 / 237 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1190 / 237 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 2524 / 237 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 5168 / 237 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 23000 / 237 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 22 / 237
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 9858 / 237 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.105 / 237
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 3.030 / 237
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 14.347 / 237
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # turboshaft, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # turboshaft, resulting in an underestimation.
 
         fuel_system_1:
             custom_attributes:
@@ -337,71 +163,10 @@ model:
                   loc: 'GLO'
                   amount: 0.333
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 918 / 22.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 923 / 22.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 115 / 22.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 244 / 22.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 500 / 22.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 2000 / 22.9  # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 2 / 22.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 954 / 22.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.01 / 22.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.162 / 22.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 0.766 / 22.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the fuel
+                # system, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't count the assembly of the fuel
+                # system, resulting in an underestimation.
 
 
     manufacturing:
@@ -588,24 +353,28 @@ model:
 
 
 methods:
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'acidification: terrestrial', 'terrestrial acidification potential (TAP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'climate change',  'global warming potential (GWP100)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'ecotoxicity: freshwater', 'freshwater ecotoxicity potential (FETP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'ecotoxicity: marine', 'marine ecotoxicity potential (METP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'ecotoxicity: terrestrial', 'terrestrial ecotoxicity potential (TETP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'energy resources: non-renewable, fossil', 'fossil fuel potential (FFP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'eutrophication: freshwater', 'freshwater eutrophication potential (FEP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'eutrophication: marine', 'marine eutrophication potential (MEP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'human toxicity: carcinogenic', 'human toxicity potential (HTPc)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'human toxicity: non-carcinogenic', 'human toxicity potential (HTPnc)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'ionising radiation', 'ionising radiation potential (IRP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'land use', 'agricultural land occupation (LOP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'material resources: metals/minerals', 'surplus ore potential (SOP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'ozone depletion', 'ozone depletion potential (ODPinfinite)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'particulate matter formation', 'particulate matter formation potential (PMFP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'photochemical oxidant formation: human health', 'photochemical oxidant formation potential: humans (HOFP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'photochemical oxidant formation: terrestrial ecosystems', 'photochemical oxidant formation potential: ecosystems (EOFP)')"
-    - "('ReCiPe 2016 v1.03, midpoint (H)', 'water use', 'water consumption potential (WCP)')"
-    - "('ReCiPe 2016 v1.03, endpoint (H)', 'total: ecosystem quality', 'ecosystem quality')"
-    - "('ReCiPe 2016 v1.03, endpoint (H)', 'total: human health', 'human health')"
-    - "('ReCiPe 2016 v1.03, endpoint (H)', 'total: natural resources', 'natural resources')"
+    - "('EF v3.1', 'acidification', 'accumulated exceedance (AE)')"
+    - "('EF v3.1', 'climate change', 'global warming potential (GWP100)')"
+    - "('EF v3.1', 'climate change: biogenic', 'global warming potential (GWP100)')"
+    - "('EF v3.1', 'climate change: fossil', 'global warming potential (GWP100)')"
+    - "('EF v3.1', 'climate change: land use and land use change', 'global warming potential (GWP100)')"
+    - "('EF v3.1', 'ecotoxicity: freshwater', 'comparative toxic unit for ecosystems (CTUe)')"
+    - "('EF v3.1', 'ecotoxicity: freshwater, inorganics', 'comparative toxic unit for ecosystems (CTUe)')"
+    - "('EF v3.1', 'ecotoxicity: freshwater, organics', 'comparative toxic unit for ecosystems (CTUe)')"
+    - "('EF v3.1', 'energy resources: non-renewable', 'abiotic depletion potential (ADP): fossil fuels')"
+    - "('EF v3.1', 'eutrophication: freshwater', 'fraction of nutrients reaching freshwater end compartment (P)')"
+    - "('EF v3.1', 'eutrophication: marine', 'fraction of nutrients reaching marine end compartment (N)')"
+    - "('EF v3.1', 'eutrophication: terrestrial', 'accumulated exceedance (AE)')"
+    - "('EF v3.1', 'human toxicity: carcinogenic', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'human toxicity: carcinogenic, inorganics', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'human toxicity: carcinogenic, organics', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'human toxicity: non-carcinogenic', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'human toxicity: non-carcinogenic, inorganics', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'human toxicity: non-carcinogenic, organics', 'comparative toxic unit for human (CTUh)')"
+    - "('EF v3.1', 'ionising radiation: human health', 'human exposure efficiency relative to u235')"
+    - "('EF v3.1', 'land use', 'soil quality index')"
+    - "('EF v3.1', 'material resources: metals/minerals', 'abiotic depletion potential (ADP): elements (ultimate reserves)')"
+    - "('EF v3.1', 'ozone depletion', 'ozone depletion potential (ODP)')"
+    - "('EF v3.1', 'particulate matter formation', 'impact on human health')"
+    - "('EF v3.1', 'photochemical oxidant formation: human health', 'tropospheric ozone concentration increase')"
+    - "('EF v3.1', 'water use', 'user deprivation potential (deprivation-weighted water consumption)')"

--- a/src/fastga_he/models/environmental_impacts/unit_tests/data/turboshaft_propulsion_lca.yml
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/data/turboshaft_propulsion_lca.yml
@@ -68,68 +68,17 @@ model:
               unit: kilogram
         
               assembly:
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
+                # For all of those we use the value from :cite:`arvidsson:2024` then we do a cross product
+                # with the mass. Originally, data from :cite:`thonemann:2024` were used, but it seemed like
+                # the production of materials was already included and as per :cite:`arvidsson:2024`, most
+                # of the things except electricity can be discarded.
                 electricity:
                   name: 'market group for electricity, high voltage'
                   loc: 'RER'
-                  amount: 219520.67 / 5485.0 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 220738.34 / 5485.0 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 27551.155 / 5485.0 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 58409.765 / 5485.0 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene:
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 118914.8 / 5485.0 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 537530 / 5485.0 # In kg
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In kg in the source but needs to be in m**3 here
-                  amount: 499.135 / 5485.0
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 89954.38395 / 5485.0 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 2.24067735 / 5485.0
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 35.53361811 / 5485.0
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
+                  amount: 2.43 # We are giving here the amount for 1 kg of OWE since we are defining a custom process
         
                 VOC:
-                  amount: 168.2270343 / 5485.0
+                  amount: 0.0049
                   name: 'VOC, volatile organic compounds'
                   categories:
                     - 'air'
@@ -152,72 +101,10 @@ model:
                   name: 'market for aluminium, cast alloy'
                   amount: 1.0 - data__propulsion__he_power_train__propeller__propeller_1__material
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 13436 / 333.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1677 / 333.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 30 / 333.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 13889 / 333.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.149 / 333.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 2.356 / 333.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 11.154 / 333.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
-
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # propeller, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # propeller, resulting in an underestimation.
         turboshaft_1:
             custom_attributes:
                 - attribute: "component"
@@ -252,71 +139,10 @@ model:
                   name: 'market for aluminium alloy, metal matrix composite'
                   amount: 0.483
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 9484 / 237 # We are giving here the amount for 1 kg of turboshaft since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 9537 / 237 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 1190 / 237 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 2524 / 237 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 5168 / 237 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 23000 / 237 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 22 / 237
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 9858 / 237 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.105 / 237
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 3.030 / 237
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 14.347 / 237
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+                # turboshaft, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't consider the assembly of the
+                # turboshaft, resulting in an underestimation.
 
         fuel_system_1:
             custom_attributes:
@@ -337,71 +163,10 @@ model:
                   loc: 'GLO'
                   amount: 0.333
         
-                # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-                # with the mass
-                electricity:
-                  name: 'market group for electricity, high voltage'
-                  loc: 'RER'
-                  amount: 918 / 22.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-        
-                gas:
-                  name: 'natural gas, burned in gas turbine'  # Not sure about this one
-                  loc: 'RoE'
-                  amount: 923 / 22.9 * 3.6 # kWh to MJ
-        
-                heat_and_steam:
-                  name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-                  loc: 'RoW'
-                  amount: 115 / 22.9 * 3.6 # kWh to MJ
-        
-                diesel:
-                  name: 'market for diesel'
-                  loc: 'Europe without Switzerland'
-                  amount: 244 / 22.9 * 3.6 / 45.6 # kWh to MJ to kg
-        
-                kerosene: # SAF aggregated in here because the process does not exist
-                  name: 'market for kerosene'
-                  loc: 'RoW'
-                  amount: 500 / 22.9 * 3.6 / 43.0 # kWh to MJ to kg
-        
-                water_in:
-                  name: 'market for water, decarbonised'
-                  loc: 'RoW'
-                  amount: 2000 / 22.9  # In m**3 in the source, in kg here (1m**3 = 1000kg)
-        
-                water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-                  amount: 2 / 22.9
-                  name: 'water'
-                  categories:
-                    - 'water'
-                    - 'ground-'
-        
-                CO2:
-                  amount: 954 / 22.9 # In kg
-                  name: 'carbon dioxide, fossil'  # this is a biosphere process
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                SOx:
-                  amount: 0.01 / 22.9
-                  name: 'sulfur dioxide'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                NOx:
-                  amount: 0.162 / 22.9
-                  name: 'nitrogen oxides'
-                  categories:
-                    - 'air'
-                    - 'lower stratosphere + upper troposphere'
-        
-                VOC:
-                  amount: 0.766 / 22.9
-                  name: 'VOC, volatile organic compounds'
-                  categories:
-                    - 'air'
+                # Originally, values from :cite:`thonemann:2024` were used for the assembly of the fuel
+                # system, but it seems like the value they give also include materials production which
+                # we don't want to count twice. This means that we don't count the assembly of the fuel
+                # system, resulting in an underestimation.
 
 
     manufacturing:

--- a/src/fastga_he/models/environmental_impacts/unit_tests/test_environmental_impact.py
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/test_environmental_impact.py
@@ -381,6 +381,14 @@ def test_wing_weight_per_fu():
 
     problem.check_partials(compact_print=True)
 
+    # Check it still works with the option enabled
+    problem = run_system(
+        LCAWingWeightPerFU(airframe_material="composite"),
+        ivc,
+    )
+
+    problem.check_partials(compact_print=True)
+
 
 def test_fuselage_weight_per_fu():
     inputs_list = [
@@ -403,6 +411,14 @@ def test_fuselage_weight_per_fu():
     assert problem.get_val(
         "data:weight:airframe:fuselage:mass_per_fu", units="kg"
     ) == pytest.approx(5.99973828e-05, rel=1e-3)
+
+    problem.check_partials(compact_print=True)
+
+    # Check that it still works with the option enabled
+    problem = run_system(
+        LCAFuselageWeightPerFU(airframe_material="composite"),
+        ivc,
+    )
 
     problem.check_partials(compact_print=True)
 
@@ -431,6 +447,14 @@ def test_htp_weight_per_fu():
 
     problem.check_partials(compact_print=True)
 
+    # Check that it still works with the option enabled
+    problem = run_system(
+        LCAHTPWeightPerFU(airframe_material="composite"),
+        ivc,
+    )
+
+    problem.check_partials(compact_print=True)
+
 
 def test_vtp_weight_per_fu():
     inputs_list = [
@@ -453,6 +477,14 @@ def test_vtp_weight_per_fu():
     assert problem.get_val(
         "data:weight:airframe:vertical_tail:mass_per_fu", units="kg"
     ) == pytest.approx(3.45032812e-06, rel=1e-3)
+
+    problem.check_partials(compact_print=True)
+
+    # Check that it still works with the option enabled
+    problem = run_system(
+        LCAVTPWeightPerFU(airframe_material="composite"),
+        ivc,
+    )
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/environmental_impacts/unit_tests/test_environmental_impact.py
+++ b/src/fastga_he/models/environmental_impacts/unit_tests/test_environmental_impact.py
@@ -736,10 +736,10 @@ def test_lca_pipistrel():
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:propeller_1"
-    ) == pytest.approx(0.0046814, rel=1e-4)
+    ) == pytest.approx(0.00275623, rel=1e-4)
     assert problem.get_val(
         "data:environmental_impact:total_natural_resources:production:propeller_1"
-    ) == pytest.approx(0.000264937, rel=1e-4)
+    ) == pytest.approx(0.000155922, rel=1e-4)
 
     assert problem.get_val("data:environmental_impact:aircraft_per_fu") == pytest.approx(
         1.70306211e-06, rel=1e-2
@@ -775,7 +775,7 @@ def test_lca_pipistrel():
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:sum"
-    ) == pytest.approx(0.1038672180654924, rel=1e-5)
+    ) == pytest.approx(0.07709378, rel=1e-5)
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:operation:battery_pack_1"
@@ -1030,11 +1030,11 @@ def test_lca_tbm900():
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:sum"
-    ) == pytest.approx(0.00204463, rel=1e-5)
+    ) == pytest.approx(0.00018677255609807612, rel=1e-5)
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:turboshaft_1"
-    ) == pytest.approx(0.00032111, rel=1e-3)
+    ) == pytest.approx(6.3786e-5, rel=1e-3)
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:operation:turboshaft_1"
@@ -1120,7 +1120,7 @@ def test_lca_tbm900_ef():
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:sum"
-    ) == pytest.approx(0.00201339, rel=1e-5)
+    ) == pytest.approx(0.000182843387198129, rel=1e-5)
     assert problem.get_val(
         "data:environmental_impact:climate_change_normalized:production:sum"
     ) == pytest.approx(
@@ -1130,12 +1130,12 @@ def test_lca_tbm900_ef():
     )
     assert problem.get_val(
         "data:environmental_impact:climate_change_normalized:production:sum"
-    ) == pytest.approx(2.666748329464666e-07, rel=1e-5)
+    ) == pytest.approx(2.4217667178560132e-08, rel=1e-5)
     assert problem.get_val(
         "data:environmental_impact:climate_change_weighted:sum"
-    ) == pytest.approx(7.664468375891523e-06, rel=1e-5)
+    ) == pytest.approx(7.613406896780802e-06, rel=1e-5)
     assert problem.get_val("data:environmental_impact:single_score") == pytest.approx(
-        1.757843076088849e-05, rel=1e-5
+        1.746314961195058e-05, rel=1e-5
     )
 
 
@@ -1175,7 +1175,7 @@ def test_lca_tbm900_ef_inputs_as_hours():
 
     assert problem.get_val(
         "data:environmental_impact:climate_change:production:sum"
-    ) == pytest.approx(0.00201339, rel=1e-5)
+    ) == pytest.approx(0.000182843387198129, rel=1e-5)
 
 
 def test_gasoline_per_fu_sr22():

--- a/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/connectors/fuel_system/components/lca_resources/lca_conf_prod.yml
@@ -17,68 +17,7 @@ ANCHOR_COMPONENT_NAME:
           loc: 'GLO'
           amount: 0.333
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 918 / 22.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 923 / 22.9 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 115 / 22.9 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 244 / 22.9 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 500 / 22.9 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 2000 / 22.9  # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 2 / 22.9
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 954 / 22.9 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.01 / 22.9
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 0.162 / 22.9
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 0.766 / 22.9
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the fuel
+        # system, but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't count the assembly of the fuel
+        # system, resulting in an underestimation.

--- a/src/fastga_he/models/propulsion/components/connectors/gearbox/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/connectors/gearbox/components/lca_resources/lca_conf_prod.yml
@@ -17,68 +17,7 @@ ANCHOR_COMPONENT_NAME:
           loc: 'GLO'
           amount: 0.250
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 4516 / 112.8 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 4541 / 112.8 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 567 / 112.8 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 1202 / 112.8 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 2461 / 112.8 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 11000 / 112.8 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 10 / 112.8
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 4695 / 112.8 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.05 / 112.8
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 0.796 / 112.8
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 3.770 / 112.8
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the gearbox,
+        # but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't consider the assembly of the
+        # gearbox, resulting in an underestimation.

--- a/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/connectors/planetary_gear/components/lca_resources/lca_conf_prod.yml
@@ -17,68 +17,7 @@ ANCHOR_COMPONENT_NAME:
           loc: 'GLO'
           amount: 0.250
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 4516 / 112.8 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 4541 / 112.8 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 567 / 112.8 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 1202 / 112.8 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 2461 / 112.8 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 11000 / 112.8 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 10 / 112.8
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 4695 / 112.8 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.05 / 112.8
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 0.796 / 112.8
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 3.770 / 112.8
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the gearbox,
+        # but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't consider the assembly of the
+        # gearbox, resulting in an underestimation.

--- a/src/fastga_he/models/propulsion/components/connectors/speed_reducer/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/connectors/speed_reducer/components/lca_resources/lca_conf_prod.yml
@@ -17,68 +17,7 @@ ANCHOR_COMPONENT_NAME:
           loc: 'GLO'
           amount: 0.250
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 4516 / 112.8 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 4541 / 112.8 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 567 / 112.8 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 1202 / 112.8 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 2461 / 112.8 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 11000 / 112.8 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 10 / 112.8
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 4695 / 112.8 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.05 / 112.8
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 0.796 / 112.8
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 3.770 / 112.8
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the gearbox,
+        # but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't consider the assembly of the
+        # gearbox, resulting in an underestimation.

--- a/src/fastga_he/models/propulsion/components/propulsor/propeller/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/propulsor/propeller/components/lca_resources/lca_conf_prod.yml
@@ -16,68 +16,7 @@ ANCHOR_COMPONENT_NAME:
           name: 'market for aluminium, cast alloy'
           amount: 1.0 - ANCHOR_COMPONENT_MATERIAL
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 13361 / 333.9 # We are giving here the amount for 1 kg of propeller since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 13436 / 333.9 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 1677 / 333.9 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 3555 / 333.9 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 7280 / 333.9 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 33000 / 333.9 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 30 / 333.9
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 13889 / 333.9 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.149 / 333.9
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 2.356 / 333.9
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 11.154 / 333.9
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+        # propeller, but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't consider the assembly of the
+        # propeller, resulting in an underestimation.

--- a/src/fastga_he/models/propulsion/components/source/turboshaft/components/lca_resources/lca_conf_prod.yml
+++ b/src/fastga_he/models/propulsion/components/source/turboshaft/components/lca_resources/lca_conf_prod.yml
@@ -32,68 +32,7 @@ ANCHOR_COMPONENT_NAME:
           name: 'market for aluminium alloy, metal matrix composite'
           amount: 0.483
 
-        # For all of those we use the value from :cite:`thonemann:2024` then we do a cross product
-        # with the mass
-        electricity:
-          name: 'market group for electricity, high voltage'
-          loc: 'RER'
-          amount: 9484 / 237 # We are giving here the amount for 1 kg of turboshaft since we are defining a custom process
-
-        gas:
-          name: 'natural gas, burned in gas turbine'  # Not sure about this one
-          loc: 'RoE'
-          amount: 9537 / 237 * 3.6 # kWh to MJ
-
-        heat_and_steam:
-          name: 'heat production, natural gas, at boiler modulating >100kW'  # Not sure about this one
-          loc: 'RoW'
-          amount: 1190 / 237 * 3.6 # kWh to MJ
-
-        diesel:
-          name: 'market for diesel'
-          loc: 'Europe without Switzerland'
-          amount: 2524 / 237 * 3.6 / 45.6 # kWh to MJ to kg
-
-        kerosene: # SAF aggregated in here because the process does not exist
-          name: 'market for kerosene'
-          loc: 'RoW'
-          amount: 5168 / 237 * 3.6 / 43.0 # kWh to MJ to kg
-
-        water_in:
-          name: 'market for water, decarbonised'
-          loc: 'RoW'
-          amount: 23000 / 237 # In m**3 in the source, in kg here (1m**3 = 1000kg)
-
-        water_out: # For some reason this line doesn't seem to affect the impacts and takes a lot of time ?!? In m**3
-          amount: 22 / 237
-          name: 'water'
-          categories:
-            - 'water'
-            - 'ground-'
-
-        CO2:
-          amount: 9858 / 237 # In kg
-          name: 'carbon dioxide, fossil'  # this is a biosphere process
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        SOx:
-          amount: 0.105 / 237
-          name: 'sulfur dioxide'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        NOx:
-          amount: 3.030 / 237
-          name: 'nitrogen oxides'
-          categories:
-            - 'air'
-            - 'lower stratosphere + upper troposphere'
-
-        VOC:
-          amount: 14.347 / 237
-          name: 'VOC, volatile organic compounds'
-          categories:
-            - 'air'
+        # Originally, values from :cite:`thonemann:2024` were used for the assembly of the
+        # turboshaft, but it seems like the value they give also include materials production which
+        # we don't want to count twice. This means that we don't consider the assembly of the
+        # turboshaft, resulting in an underestimation.


### PR DESCRIPTION
Reworked what was included in terms of energy and emissions for the estimation of the production phases. Data from :cite:`thonemann:2024` seemed to be aggregated so some impacts were counted multiple times. For airframe assembly data were replaced by the ones presented in another source from litterature. From propeller and turboshaft however, the assembly was discarded so now their impact are only related to the impacts of the materials.

Also it is now possible to include a Buy-to-Fly ratio