### PR TITLE
Advanced wing are model bugfix

### DIFF
--- a/src/fastga_he/models/loops/units_tests/data/kodiak_100.xml
+++ b/src/fastga_he/models/loops/units_tests/data/kodiak_100.xml
@@ -1,0 +1,1204 @@
+<FASTOAD_model>
+  <wing_area units="m**2" is_input="False">17.19344006061684</wing_area>
+  <data>
+    <TLAR>
+      <NPAX_design is_input="True">4.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
+      <luggage_mass_design units="kg" is_input="True">18.0<!--luggage design mass--></luggage_mass_design>
+      <range units="m" is_input="True">2118688.0<!--design range--></range>
+      <v_approach units="m/s" is_input="True">40.12666666666667<!--approach speed--></v_approach>
+      <v_cruise units="m/s" is_input="True">61.733333333333334<!--cruise speed--></v_cruise>
+      <v_max_sl units="knot" is_input="True">175.0<!--maximum speed at sea level--></v_max_sl>
+    </TLAR>
+    <geometry>
+      <has_T_tail is_input="True">0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <wing_configuration is_input="True">3.0<!--1=low wing configuration / 2=mid wing configuration / 3=high wing configuration--></wing_configuration>
+      <aircraft>
+        <wet_area units="m**2" is_input="False">107.98341989859168<!--aircraft total wet area--></wet_area>
+      </aircraft>
+      <cabin>
+        <length units="m" is_input="False">4.239999999999999<!--cabin length--></length>
+        <luggage>
+          <mass_max units="kg" is_input="True">150.0<!--maximum luggage mass--></mass_max>
+        </luggage>
+        <seats>
+          <passenger>
+            <NPAX_max is_input="True">8.0<!--maximum number of passengers in the aircraft--></NPAX_max>
+            <count_by_row is_input="True">2.0<!--number of passenger seats per row--></count_by_row>
+            <length units="m" is_input="True">1.0<!--passenger seats length--></length>
+          </passenger>
+          <pilot>
+            <length units="m" is_input="True">1.0<!--pilot seats length--></length>
+          </pilot>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio is_input="True">0.29<!--flap chord as a percentage of the wing chord--></chord_ratio>
+        <span_ratio is_input="True">0.52<!--flap span as a percentage of the wing span--></span_ratio>
+      </flap>
+      <fuselage>
+        <PAX_length units="m" is_input="True">3.8<!--length of the passenger compartment--></PAX_length>
+        <average_depth units="m" is_input="False">0.3056475313278142<!--Average fuselage depth at the vertical tail location--></average_depth>
+        <front_length units="ft" is_input="True">7.545931758530182<!--length of the front cone of the aircraft--></front_length>
+        <length units="ft" is_input="True">33.79265091863517<!--total length of the fuselage--></length>
+        <luggage_length units="m" is_input="True">0.67<!--length of the luggage compartment--></luggage_length>
+        <master_cross_section units="m**2" is_input="False">1.5601934515890306</master_cross_section>
+        <maximum_height units="ft" is_input="True">4.757217847769028<!--maximum height of the fuselage--></maximum_height>
+        <maximum_width units="m" is_input="True">1.37<!--maximum width of the fuselage--></maximum_width>
+        <rear_length units="m" is_input="True">3.76<!--length of the rear cone of the aircraft--></rear_length>
+        <volume units="m**3" is_input="False">12.060295380783204<!--Volume of the fuselage--></volume>
+        <wet_area units="m**2" is_input="False">38.905062891113516<!--fuselage wet area--></wet_area>
+      </fuselage>
+      <horizontal_tail>
+        <area units="m**2" is_input="False">6.434537279950941<!--horizontal tail area--></area>
+        <aspect_ratio is_input="True">5.01<!--horizontal tail aspect ratio--></aspect_ratio>
+        <elevator_chord_ratio is_input="True">0.45<!--elevator chord ratio--></elevator_chord_ratio>
+        <span units="m" is_input="False">5.639749610288116<!--horizontal tail span--></span>
+        <sweep_0 units="rad" is_input="False">0.0<!--sweep angle at leading edge of horizontal tail--></sweep_0>
+        <sweep_100 units="rad" is_input="False">0.0<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
+        <sweep_25 units="rad" is_input="True">0.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <sweep_50 units="rad" is_input="False">0.0</sweep_50>
+        <taper_ratio is_input="True">1.0<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.12<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <volume_coefficient is_input="False">0.8583062414824097</volume_coefficient>
+        <wet_area units="m**2" is_input="False">13.332181417198484<!--wet area of horizontal tail--></wet_area>
+        <MAC>
+          <length units="m" is_input="False">1.125698525007608<!--mean aerodynamic chord length of horizontal tail--></length>
+          <y units="m" is_input="False">1.409937402572029<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m" is_input="True">5.12<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
+              <local units="m" is_input="False">0.0<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of root chord--></local>
+            </x>
+          </at25percent>
+        </MAC>
+        <root>
+          <chord units="m" is_input="False">1.125698525007608<!--chord length at root of horizontal tail--></chord>
+        </root>
+        <tip>
+          <chord units="m" is_input="False">1.125698525007608<!--chord length at tip of horizontal tail--></chord>
+        </tip>
+        <z>
+          <from_wingMAC25 units="m" is_input="False">0.0<!--Z-position of the horizontal tail w.r.t. 25% MAC of wing Z-position--></from_wingMAC25>
+        </z>
+      </horizontal_tail>
+      <landing_gear>
+        <height units="m" is_input="False">1.0004<!--height of the landing gear--></height>
+        <type is_input="True">0.0<!--0=non-retractable / 1=retractable--></type>
+        <y units="m" is_input="False">1.88548<!--landing gear position along the wing--></y>
+      </landing_gear>
+      <propeller>
+        <diameter units="m" is_input="True">2.44<!--propeller diameter--></diameter>
+      </propeller>
+      <vertical_tail>
+        <area units="m**2" is_input="False">2.836529663074388<!--vertical tail area--></area>
+        <aspect_ratio is_input="True">1.9<!--vertical tail aspect ratio--></aspect_ratio>
+        <span units="m" is_input="False">2.323856532804647<!--vertical tail span--></span>
+        <sweep_0 units="rad" is_input="False">0.5059296659394008<!--sweep angle at leading edge of vertical tail--></sweep_0>
+        <sweep_100 units="rad" is_input="False">0.2004223358823296<!--sweep angle at trailing edge of vertical tail--></sweep_100>
+        <sweep_25 units="rad" is_input="True">0.4363323129985824<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <sweep_50 units="rad" is_input="False">0.20042233588232958</sweep_50>
+        <taper_ratio is_input="True">0.5<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.12<!--thickness ratio of vertical tail--></thickness_ratio>
+        <wet_area units="m**2" is_input="False">5.968762783486083<!--wet area of vertical tail--></wet_area>
+        <MAC>
+          <length units="m" is_input="False">1.2683817333046807<!--mean aerodynamic chord length of vertical tail--></length>
+          <z units="m" is_input="False">1.0328251256909544<!--Z-position of mean aerodynamic chord of vertical tail--></z>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m" is_input="True">5.0<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
+              <local units="m" is_input="False">0.5722129608806398<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local>
+            </x>
+          </at25percent>
+        </MAC>
+        <max_thickness>
+          <x_ratio is_input="True">0.3<!--position of the point of maximum thickness as a ratio of vertical tail chord--></x_ratio>
+        </max_thickness>
+        <root>
+          <chord units="m" is_input="False">1.6307765142488753<!--chord length at root of vertical tail--></chord>
+        </root>
+        <rudder>
+          <chord_ratio is_input="True">0.33<!--flap rudder as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg" is_input="True">26.0<!--rudder maximum deflection--></max_deflection>
+        </rudder>
+        <tip>
+          <chord units="m" is_input="False">0.8153882571244376<!--chord length at tip of vertical tail--></chord>
+        </tip>
+      </vertical_tail>
+      <wing>
+        <area units="m**2" is_input="False">23.040814198578914<!--_inp_data:geometry:wing:area--></area>
+        <aspect_ratio is_input="True">8.41<!--wing aspect ratio--></aspect_ratio>
+        <b_50 units="m" is_input="False">13.895621877205024<!--actual length between root and tip along 50% of chord--></b_50>
+        <dihedral units="rad" is_input="True">0.05235987755982989</dihedral>
+        <outer_area units="m**2" is_input="False">20.481008602239996<!--wing area outside of fuselage--></outer_area>
+        <span units="m" is_input="False">13.894741315757772<!--wing span--></span>
+        <sweep_0 units="rad" is_input="False">0.013704451137463547<!--sweep angle at leading edge of wing--></sweep_0>
+        <sweep_100_inner units="rad" is_input="False">-0.04109278184596108<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
+        <sweep_100_outer units="rad" is_input="False">-0.04109278184596108<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
+        <sweep_25 units="rad" is_input="True">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <sweep_50 units="rad" is_input="False">-0.011257919296361189</sweep_50>
+        <taper_ratio is_input="True">0.81<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio is_input="True">0.15<!--mean thickness ratio of wing--></thickness_ratio>
+        <twist units="rad" is_input="True">0.0<!--Negative twist means tip AOA is smaller than root--></twist>
+        <wet_area units="m**2" is_input="False">43.829358408793595<!--wet area of wing--></wet_area>
+        <MAC>
+          <length units="m" is_input="False">1.659112754995889<!--length of mean aerodynamic chord of wing--></length>
+          <y units="m" is_input="False">3.343860955302207<!--Y-position of mean aerodynamic chord of wing--></y>
+          <at25percent>
+            <x units="m" is_input="False">4.032727964313709<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
+          </at25percent>
+          <leading_edge>
+            <x>
+              <absolute units="m" is_input="False">3.633060228255772</absolute>
+              <local units="m" is_input="False">0.03694668446825332<!--X-position of leading edge of mean aerodynamic chord w.r.t. leading edge of root chord--></local>
+            </x>
+          </leading_edge>
+        </MAC>
+        <aileron>
+          <chord_ratio is_input="True">0.29<!--aileron chord as a percentage of the wing chord--></chord_ratio>
+        </aileron>
+        <kink>
+          <chord units="m" is_input="False">1.8068994928689022<!--chord length at wing kink--></chord>
+          <span_ratio is_input="True">0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+          <y units="m" is_input="False">0.0<!--Y-position of wing kink--></y>
+          <leading_edge>
+            <x>
+              <local units="m" is_input="False">0.0<!--X-position of leading edge at wing kink w.r.t. leading edge of root chord--></local>
+            </x>
+          </leading_edge>
+        </kink>
+        <root>
+          <chord units="m" is_input="False">1.8068994928689022<!--chord length at wing root--></chord>
+          <thickness_ratio is_input="True">0.16<!--thickness ratio at wing root--></thickness_ratio>
+          <virtual_chord units="m" is_input="False">1.8068994928689022<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
+          <y units="m" is_input="False">0.685<!--Y-position of wing root--></y>
+          <z units="m" is_input="False">-0.5804480405704877<!--Distance between the wing aerodynamic center at the root and the fuselage centerline, taken positive when wing is below the fuselage centerline--></z>
+        </root>
+        <tip>
+          <chord units="m" is_input="False">1.4635885892238107<!--chord length at wing tip--></chord>
+          <thickness_ratio is_input="True">0.133<!--thickness ratio at wing tip--></thickness_ratio>
+          <y units="m" is_input="False">6.947370657878886<!--Y-position of wing tip--></y>
+          <z units="m" is_input="False">-0.9558682980433266<!--Distance between the wing aerodynamic center at the tip and the fuselage centerline, taken positive when wing is below the fuselage centerline--></z>
+          <leading_edge>
+            <x>
+              <absolute units="m" is_input="False">3.681941269698792</absolute>
+              <local units="m" is_input="False">0.08582772591127286<!--X-position of leading edge at wing tip w.r.t. leading edge of root chord--></local>
+            </x>
+          </leading_edge>
+        </tip>
+      </wing>
+      <propulsion>
+        <engine>
+          <count is_input="True">1.0<!--number of engine--></count>
+          <layout is_input="True">3.0<!--position of engines (1=under the wing / 2=rear fuselage / 3=nose)--></layout>
+          <y_ratio is_input="True">0.0<!--engine position along wing span (if layout=1-2)--></y_ratio>
+        </engine>
+        <nacelle>
+          <from_LE units="m" is_input="False">3.633060228255772</from_LE>
+          <height units="m" is_input="True">0.61468<!--height of the nacelle--></height>
+          <length units="m" is_input="True">2.5649<!--length of the nacelle--></length>
+          <master_cross_section units="m**2" is_input="True">0.3348961044</master_cross_section>
+          <wet_area units="m**2" is_input="True">5.948054398000001<!--nacelle wet area--></wet_area>
+          <width units="m" is_input="True">0.54483<!--width of the nacelle--></width>
+          <x units="m" is_input="False">2.5649<!--position, with respect to the aircraft nose, of the furthest point of the nacelle from the nose--></x>
+          <y units="m" is_input="False">0.0<!--position of the nacelles along the wing--></y>
+        </nacelle>
+        <tank>
+          <LE_chord_percentage is_input="True">0.01<!--distance between the leading edge and the start of the wing tank as a percentage of the wing chord--></LE_chord_percentage>
+          <TE_chord_percentage is_input="True">0.01<!--distance between the trailing edge device and the start of the wing tank as a percentage of the wing chord--></TE_chord_percentage>
+          <capacity units="m**3" is_input="False">1.7970890303472875<!--Capacity of both tanks on the aircraft--></capacity>
+          <chord_array units="m" is_input="False">[1.7688131477958424, 1.7646936043491646, 1.7605740609024867, 1.7564545174558088, 1.752334974009131, 1.7482154305624529, 1.744095887115775, 1.7399763436690971, 1.7358568002224193, 1.7317372567757414, 1.7276177133290636, 1.7234981698823857, 1.7193786264357078, 1.71525908298903, 1.7111395395423519, 1.707019996095674, 1.7029004526489961, 1.6987809092023183, 1.6946613657556404, 1.6905418223089625, 1.6864222788622847, 1.6823027354156068, 1.678183191968929, 1.674063648522251, 1.669944105075573, 1.6658245616288951, 1.6617050181822173, 1.6575854747355394, 1.6534659312888615, 1.6493463878421837, 1.6452268443955058, 1.641107300948828, 1.63698775750215, 1.632868214055472, 1.6287486706087941, 1.6246291271621163, 1.6205095837154384, 1.6163900402687605, 1.6122704968220827, 1.6081509533754048, 1.604031409928727, 1.5999118664820489, 1.595792323035371, 1.5916727795886931, 1.5875532361420153, 1.5834336926953374, 1.5793141492486595, 1.5751946058019817, 1.5710750623553038, 1.566955518908626]</chord_array>
+          <cross_section_array units="m**2" is_input="False">[0.28810081529736326, 0.28616867038179755, 0.28424516994035676, 0.282330294624746, 0.2804240250866706, 0.27852634197783543, 0.27663722594994616, 0.2747566576547075, 0.272884617743825, 0.27102108686900345, 0.26916604568194824, 0.26731947483436463, 0.26548135497795755, 0.26365166676443236, 0.2618303908454941, 0.260017507872848, 0.25821299849819934, 0.2564168433732531, 0.2546290231497146, 0.2528495184792888, 0.2510783100136812, 0.24931537840459678, 0.24756070430374064, 0.24581426836281817, 0.24407605123353415, 0.24234603356759424, 0.2406241960167033, 0.23891051923256665, 0.23720498386688932, 0.23550757057137658, 0.2338182599977336, 0.2321370327976655, 0.2304638696228775, 0.22879875112507472, 0.22714165795596236, 0.22549257076724563, 0.22385147021062962, 0.22221833693781964, 0.2205931516005207, 0.21897589485043806, 0.21736654733927685, 0.21576508971874223, 0.21417150264053947, 0.2125857667563737, 0.21100786271795, 0.20943777117697365, 0.20787547278514978, 0.20632094819418356, 0.2047741780557802, 0.20323514302164475]</cross_section_array>
+          <reduced_width_array units="m" is_input="False">[1.2204810719791312, 1.2176385870009234, 1.2147961020227158, 1.211953617044508, 1.2091111320663002, 1.2062686470880923, 1.2034261621098847, 1.200583677131677, 1.1977411921534693, 1.1948987071752615, 1.1920562221970536, 1.189213737218846, 1.1863712522406382, 1.1835287672624306, 1.1806862822842228, 1.177843797306015, 1.1750013123278074, 1.1721588273495995, 1.1693163423713917, 1.166473857393184, 1.1636313724149763, 1.1607888874367687, 1.1579464024585608, 1.1551039174803532, 1.1522614325021452, 1.1494189475239376, 1.1465764625457298, 1.1437339775675222, 1.1408914925893143, 1.1380490076111067, 1.135206522632899, 1.1323640376546913, 1.1295215526764835, 1.1266790676982756, 1.1238365827200678, 1.1209940977418602, 1.1181516127636524, 1.1153091277854448, 1.112466642807237, 1.1096241578290293, 1.1067816728508215, 1.1039391878726137, 1.1010967028944059, 1.0982542179161983, 1.0954117329379904, 1.0925692479597828, 1.089726762981575, 1.0868842780033672, 1.0840417930251596, 1.0811993080469517]</reduced_width_array>
+          <relative_thickness_array is_input="False">[0.15700466455899204, 0.15668067929700547, 0.1563566940350189, 0.15603270877303232, 0.15570872351104573, 0.15538473824905916, 0.1550607529870726, 0.15473676772508602, 0.15441278246309945, 0.15408879720111285, 0.15376481193912628, 0.1534408266771397, 0.15311684141515314, 0.15279285615316657, 0.15246887089117997, 0.1521448856291934, 0.15182090036720683, 0.15149691510522026, 0.1511729298432337, 0.1508489445812471, 0.15052495931926052, 0.15020097405727395, 0.14987698879528738, 0.1495530035333008, 0.1492290182713142, 0.14890503300932764, 0.14858104774734107, 0.1482570624853545, 0.14793307722336793, 0.14760909196138133, 0.14728510669939476, 0.1469611214374082, 0.14663713617542162, 0.14631315091343505, 0.14598916565144845, 0.14566518038946188, 0.14534119512747531, 0.14501720986548874, 0.14469322460350217, 0.14436923934151558, 0.144045254079529, 0.14372126881754244, 0.14339728355555587, 0.1430732982935693, 0.1427493130315827, 0.14242532776959613, 0.14210134250760956, 0.141777357245623, 0.14145337198363642, 0.14112938672164982]</relative_thickness_array>
+          <thickness_array units="m" is_input="False">[0.277711914937221, 0.2764933926805081, 0.2752775397665208, 0.27406435619525926, 0.2728538419667233, 0.27164599708091297, 0.27044082153782845, 0.2692383153374695, 0.2680384784798363, 0.2668413109649287, 0.2656468127927468, 0.26445498396329065, 0.2632658244765601, 0.26207933433255526, 0.260895513531276, 0.25971436207272247, 0.25853587995689464, 0.2573600671837925, 0.256186923753416, 0.25501644966576514, 0.25384864492084, 0.25268350951864055, 0.25152104345916676, 0.25036124674241866, 0.24920411936839615, 0.24804966133709938, 0.24689787264852828, 0.24574875330268287, 0.24460230329956312, 0.243458522639169, 0.24231741132150061, 0.2411789693465579, 0.24004319671434085, 0.23891009342484945, 0.23777965947808372, 0.23665189487404367, 0.23552679961272932, 0.23440437369414066, 0.23328461711827764, 0.23216752988514028, 0.2310531119947286, 0.2299413634470426, 0.2288322842420823, 0.22772587437984768, 0.22662213386033866, 0.22552106268355537, 0.22442266084949777, 0.22332692835816584, 0.22223386520955957, 0.22114347140367893]</thickness_array>
+          <width_array units="m" is_input="False">[1.2204810719791312, 1.2176385870009234, 1.2147961020227158, 1.211953617044508, 1.2091111320663002, 1.2062686470880923, 1.2034261621098847, 1.200583677131677, 1.1977411921534693, 1.1948987071752615, 1.1920562221970536, 1.189213737218846, 1.1863712522406382, 1.1835287672624306, 1.1806862822842228, 1.177843797306015, 1.1750013123278074, 1.1721588273495995, 1.1693163423713917, 1.166473857393184, 1.1636313724149763, 1.1607888874367687, 1.1579464024585608, 1.1551039174803532, 1.1522614325021452, 1.1494189475239376, 1.1465764625457298, 1.1437339775675222, 1.1408914925893143, 1.1380490076111067, 1.135206522632899, 1.1323640376546913, 1.1295215526764835, 1.1266790676982756, 1.1238365827200678, 1.1209940977418602, 1.1181516127636524, 1.1153091277854448, 1.112466642807237, 1.1096241578290293, 1.1067816728508215, 1.1039391878726137, 1.1010967028944059, 1.0982542179161983, 1.0954117329379904, 1.0925692479597828, 1.089726762981575, 1.0868842780033672, 1.0840417930251596, 1.0811993080469517]</width_array>
+          <y_array units="m" is_input="False">[0.6947370657878886, 0.769882095352701, 0.8450271249175135, 0.9201721544823259, 0.9953171840471384, 1.0704622136119508, 1.1456072431767632, 1.2207522727415756, 1.295897302306388, 1.3710423318712004, 1.446187361436013, 1.5213323910008254, 1.5964774205656378, 1.6716224501304504, 1.7467674796952628, 1.8219125092600752, 1.8970575388248876, 1.9722025683897, 2.0473475979545124, 2.1224926275193248, 2.1976376570841376, 2.2727826866489496, 2.3479277162137624, 2.4230727457785743, 2.498217775343387, 2.5733628049081996, 2.648507834473012, 2.723652864037825, 2.7987978936026368, 2.8739429231674496, 2.9490879527322615, 3.0242329822970744, 3.0993780118618863, 3.174523041426699, 3.249668070991511, 3.324813100556324, 3.399958130121136, 3.4751031596859487, 3.5502481892507616, 3.6253932188155735, 3.7005382483803864, 3.7756832779451983, 3.850828307510011, 3.925973337074823, 4.001118366639636, 4.076263396204448, 4.151408425769261, 4.226553455334073, 4.3016984848988855, 4.376843514463698]</y_array>
+          <y_beginning units="m" is_input="False">0.6947370657878886</y_beginning>
+          <y_end units="m" is_input="False">4.376843514463698</y_end>
+          <y_ratio_tank_beginning is_input="True">0.1<!--start of the tank as a percentage of the wing span--></y_ratio_tank_beginning>
+          <y_ratio_tank_end is_input="True">0.63<!--end of the tank as a percentage of the wing span--></y_ratio_tank_end>
+        </tank>
+      </propulsion>
+    </geometry>
+    <handling_qualities>
+      <stick_fixed_static_margin is_input="False">0.2091075501924352<!--stick fixed static margin--></stick_fixed_static_margin>
+      <stick_free_static_margin is_input="False">0.10646909321012676<!--stick free static margin--></stick_free_static_margin>
+      <static_margin>
+        <target is_input="True">0.2<!--static margin we want to achieve--></target>
+      </static_margin>
+    </handling_qualities>
+    <propulsion>
+      <fuel_type is_input="True">3.0<!--engine fuel type (1.0 - gasoline, 2.0 - gasoil)--></fuel_type>
+      <he_power_train>
+        <mass units="kg" is_input="False">319.08967613712184</mass>
+        <thrust_distribution is_input="True">1.0</thrust_distribution>
+        <CG>
+          <x units="m" is_input="False">1.211921758015646</x>
+        </CG>
+        <cruise>
+          <CD0 is_input="False">0.0</CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.0</CD0>
+        </low_speed>
+        <fuel_system>
+          <fuel_system_1>
+            <connected_volume units="m**3" is_input="False">1.1363896348783147<!--Capacity of the connected tank in terms of volume--></connected_volume>
+            <fuel_distribution is_input="True">[1.0, 1.0]</fuel_distribution>
+            <fuel_type is_input="True">3.0<!--Type of fuel flowing in the system, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <mass units="lbm" is_input="False">120.08097771981059<!--Weight of the fuel system--></mass>
+            <number_engine is_input="False">1.0<!--Number of engine connected to this fuel system--></number_engine>
+            <total_fuel_flowed units="kg" is_input="False">916.8783077197444<!--Total amount of fuel that flowed through the system--></total_fuel_flowed>
+            <CG>
+              <x units="m" is_input="False">2.3<!--X position of the fuel system center of gravity--></x>
+              <y units="m" is_input="False">0.0<!--Y position of the ICE center of gravity--></y>
+            </CG>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+          </fuel_system_1>
+        </fuel_system>
+        <fuel_tank>
+          <fuel_tank_1>
+            <capacity units="kg" is_input="False">461.39691955329334<!--Capacity of the tank in terms of weight--></capacity>
+            <fuel_consumed_mission units="kg" is_input="False">458.4391538598722<!--Amount of fuel from that tank which will be consumed during mission (does not account for takeoff and initial climb, the amount used for sizing does)--></fuel_consumed_mission>
+            <fuel_total_mission units="kg" is_input="False">461.39691955329334<!--Total amount of fuel loaded in the tank for the mission--></fuel_total_mission>
+            <fuel_type is_input="True">3.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <mass units="kg" is_input="False">4.568286332210825<!--Weight of the fuel tanks--></mass>
+            <unusable_fuel_mission units="kg" is_input="False">4.568286332210825<!--Amount of trapped fuel in the tank--></unusable_fuel_mission>
+            <volume units="m**3" is_input="False">0.573876765613549<!--Capacity of the tank in terms of volume--></volume>
+            <CG>
+              <x units="m" is_input="False">4.462616605753716<!--X position of the battery center of gravity--></x>
+              <y units="m" is_input="False">2.535790290125793<!--Y position of the fuel tank center of gravity--></y>
+              <y_ratio is_input="True">0.365<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <dimension>
+              <height units="m" is_input="False">0.23096472810910038<!--Value of the length of the tank in the z-direction, computed differently based on the location of the tank--></height>
+              <length units="m" is_input="False">1.1291608929778238<!--Value of the length of the tank in the x-direction, computed differently based on the location of the tank--></length>
+              <ref_chord units="m" is_input="False">1.710849837845188<!--Reference wing chord for the tank--></ref_chord>
+              <width units="m" is_input="False">2.2004786133520366<!--Value of the length of the tank in the y-direction, computed differently based on the location of the tank--></width>
+            </dimension>
+            <distributed_tanks>
+              <chord_slope is_input="False">0.0<!--When tank is considered as a distributed mass, the rate at which the chord varies--></chord_slope>
+              <start_chord units="m" is_input="False">1.6352440410463565<!--When tank is considered as a distributed mass, the chord at the start--></start_chord>
+              <y_ratio_end is_input="False">0.523367728001997<!--When tank is considered as a distributed mass, the position of the end as a ratio of the half-span--></y_ratio_end>
+              <y_ratio_start is_input="False">0.206632271998003<!--When tank is considered as a distributed mass, the position of the start as a ratio of the half-span--></y_ratio_start>
+            </distributed_tanks>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+          </fuel_tank_1>
+          <fuel_tank_2>
+            <capacity units="kg" is_input="False">461.39691955329334<!--Capacity of the tank in terms of weight--></capacity>
+            <fuel_consumed_mission units="kg" is_input="False">458.4391538598722<!--Amount of fuel from that tank which will be consumed during mission (does not account for takeoff and initial climb, the amount used for sizing does)--></fuel_consumed_mission>
+            <fuel_total_mission units="kg" is_input="False">461.39691955329334<!--Total amount of fuel loaded in the tank for the mission--></fuel_total_mission>
+            <fuel_type is_input="True">3.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <mass units="kg" is_input="False">4.568286332210825<!--Weight of the fuel tanks--></mass>
+            <unusable_fuel_mission units="kg" is_input="False">4.568286332210825<!--Amount of trapped fuel in the tank--></unusable_fuel_mission>
+            <volume units="m**3" is_input="False">0.573876765613549<!--Capacity of the tank in terms of volume--></volume>
+            <CG>
+              <x units="m" is_input="False">4.462616605753716<!--X position of the battery center of gravity--></x>
+              <y units="m" is_input="False">2.535790290125793<!--Y position of the fuel tank center of gravity--></y>
+              <y_ratio is_input="True">0.365<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <dimension>
+              <height units="m" is_input="False">0.23096472810910038<!--Value of the length of the tank in the z-direction, computed differently based on the location of the tank--></height>
+              <length units="m" is_input="False">1.1291608929778238<!--Value of the length of the tank in the x-direction, computed differently based on the location of the tank--></length>
+              <ref_chord units="m" is_input="False">1.710849837845188<!--Reference wing chord for the tank--></ref_chord>
+              <width units="m" is_input="False">2.2004786133520366<!--Value of the length of the tank in the y-direction, computed differently based on the location of the tank--></width>
+            </dimension>
+            <distributed_tanks>
+              <chord_slope is_input="False">0.0<!--When tank is considered as a distributed mass, the rate at which the chord varies--></chord_slope>
+              <start_chord units="m" is_input="False">1.6352440410463565<!--When tank is considered as a distributed mass, the chord at the start--></start_chord>
+              <y_ratio_end is_input="False">0.523367728001997<!--When tank is considered as a distributed mass, the position of the end as a ratio of the half-span--></y_ratio_end>
+              <y_ratio_start is_input="False">0.206632271998003<!--When tank is considered as a distributed mass, the position of the start as a ratio of the half-span--></y_ratio_start>
+            </distributed_tanks>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+          </fuel_tank_2>
+        </fuel_tank>
+        <propeller>
+          <propeller_1>
+            <activity_factor is_input="True">150.0<!--Activity factor of the propeller--></activity_factor>
+            <advance_ratio_max is_input="False">1.1187790283181578<!--Maximum value of the propeller tip mach Number--></advance_ratio_max>
+            <blade_twist units="rad" is_input="True">0.4363323129985824<!--Twist between the propeller blade root and tip--></blade_twist>
+            <cl_clean_ref is_input="False">0.0<!--Value of the clean lift coefficient of the section behind the propeller for reference wing lift coefficient--></cl_clean_ref>
+            <depth units="cm" is_input="False">73.2<!--Depth of the propeller--></depth>
+            <depth_to_diameter_ratio is_input="True">0.3<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="cm" is_input="True">244.0<!--Diameter of the propeller--></diameter>
+            <diameter_to_chord_ratio is_input="False">1.357505606827178<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></diameter_to_chord_ratio>
+            <diameter_to_span_ratio is_input="False">0.35121200813329867<!--Diameter of the propeller as a ratio of the wing half span--></diameter_to_span_ratio>
+            <flapped_ratio is_input="False">0.0<!--Portion of the span, downstream of the propeller, which has flaps--></flapped_ratio>
+            <from_wing_AC units="m" is_input="False">4.047838417004744<!--Distance between the propeller and the wing aerodynamic center--></from_wing_AC>
+            <from_wing_LE_ratio is_input="False">2.25203415844852<!--Distance between the propeller and the wing leading edge as a ratio of the reference chord behind the propeller--></from_wing_LE_ratio>
+            <installation_angle units="rad" is_input="True">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
+            <mass units="kg" is_input="False">37.72884819685403</mass>
+            <material is_input="True">1.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades is_input="True">4.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_max units="1/min" is_input="False">2000.0<!--Maximum value of the propeller rpm--></rpm_max>
+            <rpm_landing units="1/min" is_input="True">2000.0<!--RPM of the propeller for the points--></rpm_landing>
+            <rpm_mission units="1/min" is_input="True">2000.0<!--RPM of the propeller for the points--></rpm_mission>
+            <solidity is_input="True">0.2<!--Solidity of the propeller--></solidity>
+            <tip_mach_max is_input="False">0.6905018797320669<!--Maximum value of the propeller tip mach Number--></tip_mach_max>
+            <torque_max units="N*m" is_input="False">2364.1093555077787<!--Maximum value of the propeller torque--></torque_max>
+            <torque_rating units="N*m" is_input="False">2328.1309751344734<!--Maximum value of the propeller torque used for the sizing--></torque_rating>
+            <wing_chord_ref units="m" is_input="False">1.7974143073359936<!--Value of the wing chord behind the propeller--></wing_chord_ref>
+            <CG>
+              <x units="m" is_input="False">0.36600000000000005<!--X position of the propeller center of gravity--></x>
+              <y units="m" is_input="False">0.0<!--Y position of the DC bus center of gravity--></y>
+            </CG>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+          </propeller_1>
+        </propeller>
+        <turboshaft>
+          <turboshaft_1>
+            <mass units="kg" is_input="False">217.75644000000003<!--Installed weight of the turboshaft--></mass>
+            <power_max units="kW" is_input="False">555.0553595410411<!--Maximum power the turboshaft has to provide--></power_max>
+            <power_offtake units="kW" is_input="True">30.0<!--Mechanical offtake on the turboshaft, is added to shaft power out--></power_offtake>
+            <power_rating units="kW" is_input="True">551.0<!--Flat rating of the turboshaft--></power_rating>
+            <shaft_power_rating units="kW" is_input="False">551.0<!--Value of the maximum power the turboshaft can provide used for power rate--></shaft_power_rating>
+            <uninstalled_mass units="kg" is_input="False">181.46370000000002<!--Uninstalled weight of the turboshaft--></uninstalled_mass>
+            <CG>
+              <x units="m" is_input="False">0.9499327175<!--X position of the turboshaft center of gravity--></x>
+              <y units="m" is_input="False">0.0<!--Y position of the turboshaft center of gravity--></y>
+            </CG>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <design_point>
+              <OPR is_input="True">7.0<!--OPR of the turboshaft at the design point--></OPR>
+              <T41t units="degK" is_input="True">1400.0<!--Total temperature at the output of the combustion chamber of the turboshaft at the design point--></T41t>
+              <power_ratio is_input="True">1.2<!--Ratio of the thermodynamic power divided by the rated power, typical values on the PT6A family is between 1.3 and 2.5--></power_ratio>
+            </design_point>
+            <emission_index>
+              <CO units="g/kg" is_input="True">5.0</CO>
+              <CO2 units="g/kg" is_input="True">3155.0</CO2>
+              <H2O units="g/kg" is_input="True">1237.0</H2O>
+              <HC units="g/kg" is_input="True">0.5</HC>
+              <NOx units="g/kg" is_input="True">11.4</NOx>
+              <SOx units="g/kg" is_input="True">0.8</SOx>
+            </emission_index>
+            <engine>
+              <height units="mm" is_input="False">531.9724870869537<!--Height of the turboshaft--></height>
+              <length units="mm" is_input="False">1652.0569<!--Length of the turboshaft--></length>
+              <width units="mm" is_input="False">531.9724870869537<!--Width of the turboshaft--></width>
+            </engine>
+            <limit>
+              <ITT units="degK" is_input="True">1080.0<!--Limit ITT of the turboshaft--></ITT>
+              <OPR is_input="True">8.5<!--Limit OPR of the turboshaft--></OPR>
+            </limit>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+            <nacelle>
+              <height units="m" is_input="False">0.5851697357956492<!--Height of the turboshaft nacelle--></height>
+              <length units="m" is_input="False">1.899865435<!--Length of the turboshaft nacelle--></length>
+              <wet_area units="m**2" is_input="False">4.446975018584944<!--Wet area of the turboshaft nacelle--></wet_area>
+              <width units="m" is_input="False">0.5851697357956492<!--Width of the turboshaft nacelle--></width>
+            </nacelle>
+          </turboshaft_1>
+        </turboshaft>
+      </he_power_train>
+      <turboprop>
+        <design_point>
+          <OPR is_input="True">7.0<!--overall pressure ratio at the turboprop design point--></OPR>
+          <altitude units="m" is_input="True">0.0<!--altitude of the turboprop design point--></altitude>
+          <mach is_input="True">0.0<!--mach number at the turboprop design point--></mach>
+          <power units="kW" is_input="True">660.6902<!--desired turboprop thermodynamic power at the design point--></power>
+          <turbine_entry_temperature units="degK" is_input="True">1330.0<!--turboprop turbine entry temperature at the design point--></turbine_entry_temperature>
+        </design_point>
+        <off_design>
+          <bleed_usage is_input="True">1.0<!--usage of the bleed in off-design point, 0 for "low" or 1 for "high"--></bleed_usage>
+          <itt_limit units="degK" is_input="True">1080.0<!--inter turbine temperature limitation in off-design point--></itt_limit>
+          <opr_limit is_input="True">8.5<!--pressure ratio limitation in off-design point--></opr_limit>
+          <power_limit units="kW" is_input="True">551.0<!--mechanical power limitation in off-design point--></power_limit>
+        </off_design>
+      </turboprop>
+    </propulsion>
+    <aerodynamics>
+      <cruise>
+        <mach is_input="False">0.1879888301707729<!--mach number representative of high speed aerodynamics--></mach>
+        <unit_reynolds units="1/m" is_input="False">3300230.1753227375<!--unitary reynolds number representative of high speed aerodynamics--></unit_reynolds>
+        <neutral_point>
+          <free_elevator_factor is_input="False">0.6852624584723654<!--free elevator factor for computation of stick free static margin in high speed--></free_elevator_factor>
+          <stick_fixed>
+            <x is_input="False">0.6465487177929825<!--distance between the leading edge of the wing at the MAC and the stick fixed aerodynamic center--></x>
+          </stick_fixed>
+          <stick_free>
+            <x is_input="False">0.5439102608106741<!--distance between the leading edge of the wing at the MAC and the stick free aerodynamic center--></x>
+          </stick_free>
+        </neutral_point>
+      </cruise>
+      <fuselage>
+        <Cn_beta units="1/rad" is_input="False">-0.050567282259101176<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></Cn_beta>
+        <Cy_beta units="1/rad" is_input="False">-0.23109004376246653</Cy_beta>
+        <cm_alpha units="1/rad" is_input="False">-0.19947270478595264<!--derivative of fuselage pitching moment coefficient with respect to angle of attack--></cm_alpha>
+        <cruise>
+          <CD0 is_input="False">0.00484743607786045<!--profile drag coefficient for fuselage in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.005024607243480356<!--profile drag coefficient for fuselage in low speed conditions--></CD0>
+        </low_speed>
+      </fuselage>
+      <horizontal_tail>
+        <efficiency is_input="False">0.9<!--ratio between the dynamic pressure at the tail and the free stream dynamic pressure--></efficiency>
+        <airfoil>
+          <CL_alpha units="1/rad" is_input="False">6.346743422659892<!--horizontal tail airfoil lift curve slope--></CL_alpha>
+        </airfoil>
+        <cruise>
+          <CD0 is_input="False">0.001867787983497091<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
+          <CDp is_input="False">[0.11573, 0.09386, 0.07479, 0.05876, 0.04574, 0.03612, 0.02931, 0.02458, 0.02116, 0.01859, 0.01661, 0.01504, 0.01373, 0.01229, 0.0111, 0.0101, 0.00917, 0.00834, 0.00761, 0.00703, 0.00651, 0.00593, 0.00541, 0.00491, 0.00437, 0.00394, 0.00351, 0.00312, 0.00274, 0.00243, 0.00214, 0.00187, 0.00163, 0.00123, 0.00106, 0.00093, 0.00084, 0.00078, 0.00074, 0.00073, 0.00074, 0.00077, 0.00084, 0.00093, 0.00106, 0.00123, 0.00163, 0.00187, 0.00214, 0.00243, 0.00274, 0.00312, 0.00351, 0.00394, 0.00437, 0.00491, 0.00541, 0.00593, 0.00651, 0.00703, 0.00761, 0.00833, 0.00917, 0.0101, 0.0111, 0.01229, 0.01373, 0.01504, 0.01661, 0.01858, 0.02115, 0.02456, 0.02927, 0.03606, 0.04584, 0.05874, 0.07488, 0.09386, 0.11575, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--pressure drag coefficient of the horizontal tail profile for various angle of attack in cruise conditions--></CDp>
+          <CL is_input="False">[-1.3324, -1.4205, -1.4964, -1.5564, -1.6001, -1.6243, -1.6329, -1.6294, -1.6178, -1.6004, -1.5781, -1.5522, -1.5173, -1.479, -1.4364, -1.3903, -1.3428, -1.2947, -1.2459, -1.1978, -1.151, -1.1047, -1.0403, -0.9748, -0.9091, -0.8457, -0.7843, -0.7297, -0.6763, -0.6214, -0.5661, -0.5106, -0.4544, -0.3416, -0.2854, -0.2289, -0.1717, -0.1147, -0.0571, -0.0, 0.0571, 0.1148, 0.1717, 0.2288, 0.2854, 0.3415, 0.4544, 0.5106, 0.5661, 0.6214, 0.6763, 0.7298, 0.7844, 0.8457, 0.9092, 0.975, 1.0404, 1.1049, 1.1509, 1.1978, 1.246, 1.2948, 1.343, 1.3905, 1.4366, 1.4792, 1.5177, 1.5528, 1.5789, 1.6014, 1.619, 1.6308, 1.6346, 1.6263, 1.6011, 1.5586, 1.4981, 1.4229, 1.3347, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--lift coefficient of the horizontal tail profile for various angle of attack in cruise conditions--></CL>
+          <CL0 is_input="False">-0.00777341139768523<!--lift coefficient of the horizontal tail when aircraft AOA is null in cruise conditions--></CL0>
+          <CL_alpha units="1/rad" is_input="False">0.7168306129084732<!--derivative of lift coefficient of horizontal tail with respect to aircraft angle of attack in cruise conditions--></CL_alpha>
+          <CL_alpha_isolated units="1/rad" is_input="False">1.1360692060195987<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha_isolated>
+          <downwash_gradient is_input="False">0.36929134078192405</downwash_gradient>
+          <induced_drag_coefficient is_input="False">0.12700275157681337<!--coefficient to multiply by the lift coefficient squared to get induced drag in cruise conditions--></induced_drag_coefficient>
+          <reynolds is_input="False">3715064.240546405<!--reynolds number on the horizontal tail in cruise conditions--></reynolds>
+          <hinge_moment>
+            <CH_alpha units="1/rad" is_input="False">-0.33355252814440267<!--derivative of 3D hinge moment coefficient with respect to the local angle of attack in cruise conditions--></CH_alpha>
+            <CH_alpha_2D units="1/rad" is_input="False">-0.4667072299984556<!--derivative of 2D hinge moment coefficient with respect to the local angle of attack in cruise conditions--></CH_alpha_2D>
+            <CH_delta units="1/rad" is_input="False">-0.7111592698178564<!--derivative of 3D hinge moment coefficient with respect to elevator deflection in cruise conditions--></CH_delta>
+            <CH_delta_2D units="1/rad" is_input="False">-0.6378435474736034<!--derivative of 2D hinge moment coefficient with respect to elevator deflection in cruise conditions--></CH_delta_2D>
+          </hinge_moment>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.0019531841293979617<!--profile drag coefficient for horizontal tail in low speed conditions--></CD0>
+          <CDp is_input="False">[0.0007485691182389147, 0.0007385691182389147, 0.0007485691182389147, 0.0007885691182389147, 0.0008542845591194572, 0.0009442845591194572, 0.0010685691182389147, 0.0012385691182389149, 0.0014285691182389147, 0.001652853677358372, 0.0018971382364778293, 0.002171422795597287, 0.002455707354716744, 0.002771422795597287, 0.0031199919138362015, 0.0035399919138362013, 0.003962845591194574, 0.004435699268552946, 0.0054771301503140305, 0.0064471220641502324, 0.007627113977986434, 0.008979967655344806, 0.010757113977986434, 0.012812813246539378, 0.015682829418866978, 0.019318463998109534, 0.024962691954082405, 0.034612594920116826, 0.05212816481004899, 0.08356068695469164, 0.004899983827672403, 0.005987122064150233, 0.00702426838679186, 0.008212829418866975, 0.009759967655344806, 0.011734244128300465, 0.01409567501006155, 0.01739848017043713, 0.021769870621379226, 0.029104074318860702, 0.042052530230806434, 0.06560662072199473, 0.019334179438990077, 0.01740276472955659, 0.015687113977986434, 0.01409567501006155, 0.012818528687419922, 0.011728528687419922, 0.010757113977986434, 0.009759967655344806, 0.008979967655344806, 0.008212829418866975, 0.0076328294188669765, 0.00702426838679186, 0.005987122064150233, 0.0054771301503140305, 0.004899983827672403, 0.004429983827672403, 0.0035399919138362013, 0.002771422795597287, 0.002171422795597287, 0.001652853677358372, 0.08372069504085543, 0.052216733928287906, 0.06577375895847255, 0.04214253023080644, 0.0012385691182389149, 0.0347040177157141, 0.029154074318860697, 0.02499697651320186, 0.02179415518049868, 0.0064471220641502324, 0.0009442845591194572, 0.0007885691182389147, 0.003962845591194574, 0.0031199919138362015, 0.002455707354716744, 0.0018971382364778293, 0.001432853677358372, 0.0010685691182389147, 0.0008542845591194572, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--pressure drag coefficient of the horizontal tail profile for various angle of attack in low speed conditions--></CDp>
+          <CL is_input="False">[-0.056257154408805424, -0.0, 0.056257154408805424, 0.11291430881761085, 0.16901430881761084, 0.22512861763522168, 0.28078577204402716, 0.33600008086163796, 0.3913143896792488, 0.4463858529056651, 0.5011144705408868, 0.5551716249496922, 0.6092573969937194, 0.6625002425849139, 0.7164002425849139, 0.7756141470943348, 0.83639959569181, 0.902313904509421, 1.0307281324653936, 1.1289146322641628, 1.2210717866729683, 1.316886095490579, 1.408086095490579, 1.4932148748490768, 1.555972029257882, 1.6012158451887324, 1.632559014226479, 1.6411165729434742, 1.6057029110189673, 1.4915475355661973, 0.96729959569181, 1.0843004043081899, 1.1740145514025246, 1.2697574778553573, 1.363986095490579, 1.4519434116226604, 1.530072029257882, 1.578958609918289, 1.6193302348679812, 1.6405877935849766, 1.6309882787548045, 1.561017785868044, -1.6001158451887325, -1.5781157643270944, -1.5552720292578823, -1.5296291836666875, -1.4929148748490766, -1.451700566031466, -1.407886095490579, -1.3637860954905792, -1.3167432498993845, -1.269657477855357, -1.2209717866729681, -1.1740145514025246, -1.0845004043081898, -1.0305852868741991, -0.96719959569181, -0.9021139045094209, -0.7755141470943349, -0.6625002425849139, -0.5551716249496922, -0.4463858529056651, -1.4882760723397812, -1.6030743742453837, -1.5577892490944603, -1.628531124345999, -0.3360572352704434, -1.6388880361698905, -1.6387877935849766, -1.6310590142264787, -1.6180445436855921, -1.1290146322641628, -0.22512861763522168, -0.11285715440880542, -0.8363424412830046, -0.7164002425849139, -0.6092573969937194, -0.5010716249496923, -0.3913143896792488, -0.28078577204402716, -0.16901430881761084, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--lift coefficient of the horizontal tail profile for various angle of attack in low speed conditions--></CL>
+          <CL0 is_input="False">-0.00760455375168389<!--lift coefficient of the horizontal tail when aircraft AOA is null in low speed conditions--></CL0>
+          <CL_alpha units="1/rad" is_input="False">0.7135306501962264<!--derivative of lift coefficient of horizontal tail with respect to aircraft angle of attack in low speed conditions--></CL_alpha>
+          <CL_alpha_isolated units="1/rad" is_input="False">1.1236623482359371<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in low speed conditions--></CL_alpha_isolated>
+          <CL_max_clean is_input="False">0.26250768217639087<!--maximum horizontal tail lift coefficient in low speed altitude--></CL_max_clean>
+          <CL_min_clean is_input="False">-0.2603359388529299<!--minimum horizontal tail lift coefficient in low speed altitude--></CL_min_clean>
+          <CL_ref is_input="False">0.11693003784651684<!--reference horizontal tail lift coefficient corresponding to the lift repartition in CL_vector--></CL_ref>
+          <CL_vector is_input="False">[0.1999135001921556, 0.19953590100354465, 0.19877067140406154, 0.19759712481341213, 0.1959825964959897, 0.1938802577840861, 0.19122577759073117, 0.18793234721179344, 0.18388325974071312, 0.17892065537606383, 0.17282793175711278, 0.1653009997560809, 0.15589820139245492, 0.14394455679556747, 0.12832170236306845, 0.10689812906634995, 0.07429991227572466, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--horizontal tail lift coefficient repartition along the span corresponding to the lift coefficient in CL_ref--></CL_vector>
+          <Y_vector units="m" is_input="False">[0.06583243907529233, 0.197497317225877, 0.32916219537646163, 0.4608270735270463, 0.592491951677631, 0.7241568298282156, 0.8558217079788003, 0.987486586129385, 1.1191514642799696, 1.250816342430554, 1.382481220581139, 1.5141460987317235, 1.6458109768823084, 1.7774758550328928, 1.9091407331834775, 2.0408056113340622, 2.172470489484647, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--point along the span at which the lift repartition on the horizontal tail is sampled--></Y_vector>
+          <downwash_gradient is_input="False">0.36525836011354396</downwash_gradient>
+          <induced_drag_coefficient is_input="False">0.1276156067924717<!--coefficient to multiply by the lift coefficient squared to get induced drag in low speed conditions--></induced_drag_coefficient>
+          <reynolds is_input="False">3092292.637435131<!--reynolds number on the horizontal tail in low speed conditions--></reynolds>
+          <clean>
+            <alpha_aircraft_max units="deg" is_input="False">21.079097687439926<!--positive aircraft angle of attack that gives a stalled horizontal tail--></alpha_aircraft_max>
+            <alpha_aircraft_min units="deg" is_input="False">-20.904708925603543<!--negative aircraft angle of attack that gives a stalled horizontal tail--></alpha_aircraft_min>
+          </clean>
+          <root>
+            <CL_max_2D is_input="False">1.6228600373661999<!--maximum lift coefficient at the root section of the horizontal tail given with respect to the horizontal tail surface--></CL_max_2D>
+            <CL_min_2D is_input="False">-1.609434009518781<!--minimum lift coefficient at the root section of the horizontal tail given with respect to the horizontal tail surface--></CL_min_2D>
+          </root>
+          <tip>
+            <CL_max_2D is_input="False">1.6228600373661999<!--maximum lift coefficient at the tip section of the horizontal tail given with respect to the horizontal tail surface--></CL_max_2D>
+            <CL_min_2D is_input="False">-1.609434009518781<!--minimum lift coefficient at the tip section of the horizontal tail given with respect to the horizontal tail surface--></CL_min_2D>
+          </tip>
+        </low_speed>
+        <MAC>
+          <low_speed>
+            <reynolds is_input="False">2933606.3778192815<!--reynolds number at the horizontal tail mean aerodynamic chord in low speed conditions--></reynolds>
+          </low_speed>
+        </MAC>
+        <root>
+          <low_speed>
+            <reynolds is_input="False">2933606.3778192815<!--reynolds number at the horizontal tail root section in low speed conditions--></reynolds>
+          </low_speed>
+        </root>
+        <tip>
+          <low_speed>
+            <reynolds is_input="False">2933606.3778192815<!--reynolds number at the horizontal tail tip section in low speed conditions--></reynolds>
+          </low_speed>
+        </tip>
+      </horizontal_tail>
+      <low_speed>
+        <mach is_input="False">0.11791720574849976<!--mach number representative of low speed aerodynamics--></mach>
+        <unit_reynolds units="1/m" is_input="False">2746998.9244360356<!--unitary reynolds number representative of low speed aerodynamics--></unit_reynolds>
+      </low_speed>
+      <vertical_tail>
+        <efficiency is_input="True">0.95</efficiency>
+        <k_ar_effective is_input="False">1.263819349655804<!--coefficient to multiply the vertical tail aspect ratio to get the effective aspect ratio which includes fuselage and horizontal tail end-plate effect--></k_ar_effective>
+        <airfoil>
+          <CL_alpha units="1/rad" is_input="False">6.346743422659892<!--vertical tail airfoil lift curve slope--></CL_alpha>
+        </airfoil>
+        <cruise>
+          <CD0 is_input="False">0.0008407315935462978<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">2.8838482417681357<!--derivative of the vertical tail side force coefficient with respect to the local sideslip angle in cruise conditions--></CL_alpha>
+          <Cn_beta units="1/rad" is_input="False">0.1015884085943657</Cn_beta>
+          <Cy_beta units="1/rad" is_input="False">-0.281196151883138</Cy_beta>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.0008792174001878641<!--profile drag coefficient for vertical tail in low speed conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">2.85395362674259<!--derivative of the vertical tail side force coefficient with respect to the local sideslip angle in low speed conditions--></CL_alpha>
+          <Cn_beta units="1/rad" is_input="False">0.10181313717419767</Cn_beta>
+          <Cy_beta units="1/rad" is_input="False">-0.27828120976327897</Cy_beta>
+        </low_speed>
+        <MAC>
+          <low_speed>
+            <reynolds is_input="False">3305443.384414969<!--reynolds number at the horizontal tail in cruise conditions--></reynolds>
+          </low_speed>
+        </MAC>
+      </vertical_tail>
+      <wing>
+        <Cy_beta units="1/rad" is_input="False">-0.01719</Cy_beta>
+        <airfoil>
+          <CL_alpha units="1/rad" is_input="False">6.437758514647116<!--wing tail airfoil lift curve slope--></CL_alpha>
+        </airfoil>
+        <cruise>
+          <CD0 is_input="False">0.005448161714714891<!--profile drag coefficient for wing in cruise conditions--></CD0>
+          <CDp is_input="False">[0.06494, 0.0528, 0.03809, 0.03138, 0.02292, 0.01887, 0.01602, 0.0138, 0.01203, 0.0106, 0.00928, 0.0081, 0.0071, 0.00626, 0.00555, 0.00492, 0.00435, 0.00384, 0.00339, 0.00299, 0.00265, 0.00236, 0.0021, 0.00188, 0.0017, 0.00153, 0.00143, 0.00136, 0.00132, 0.00143, 0.00142, 0.00146, 0.0015, 0.00157, 0.00165, 0.0017, 0.00181, 0.00196, 0.00215, 0.00237, 0.00262, 0.00289, 0.00318, 0.0035, 0.00384, 0.00423, 0.00466, 0.00515, 0.00568, 0.00621, 0.0068, 0.00745, 0.00821, 0.00922, 0.01019, 0.01012, 0.01031, 0.01152, 0.01271, 0.01405, 0.01572, 0.0176, 0.02018, 0.02383, 0.02852, 0.03474, 0.04345, 0.05548, 0.07171, 0.09139, 0.11112, 0.12942, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--pressure drag coefficient of the wing profile for various angle of attack in cruise conditions--></CDp>
+          <CL is_input="False">[-1.1077, -1.1386, -1.2087, -1.2302, -1.2824, -1.264, -1.2315, -1.1924, -1.15, -1.1085, -1.0555, -0.9942, -0.9324, -0.8757, -0.8234, -0.7706, -0.7165, -0.6614, -0.6064, -0.5504, -0.4939, -0.4371, -0.3797, -0.3223, -0.2651, -0.208, -0.1509, -0.0934, -0.0362, 0.0194, 0.0779, 0.136, 0.1943, 0.2525, 0.3105, 0.3653, 0.4211, 0.4772, 0.5335, 0.5908, 0.6472, 0.7037, 0.7594, 0.8138, 0.8666, 0.9247, 0.9885, 1.0526, 1.1158, 1.1659, 1.2141, 1.2641, 1.3138, 1.361, 1.4081, 1.4649, 1.5186, 1.5593, 1.5993, 1.6317, 1.653, 1.6752, 1.6911, 1.6994, 1.7038, 1.7009, 1.6835, 1.6452, 1.5797, 1.4939, 1.4127, 1.3468, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--lift coefficient of the wing profile for various angle of attack in cruise conditions--></CL>
+          <CL0_clean is_input="False">0.09042927301755159<!--wing lift coefficient at zero aircraft angle of attack in cruise conditions and with no flaps deployed--></CL0_clean>
+          <CL_alpha units="1/rad" is_input="False">4.878485260402408<!--wing lift coefficient slope with respect to aircraft angle of attack in cruise conditions--></CL_alpha>
+          <CL_ref is_input="False">0.944224164933877</CL_ref>
+          <CM0_clean is_input="False">-0.020809378490821265<!--wing pitching moment coefficient in cruise conditions and with no flaps deployed--></CM0_clean>
+          <induced_drag_coefficient is_input="False">0.04948445089854031<!--coefficient to multiply by the lift coefficient squared to get wing induced drag in cruise conditions--></induced_drag_coefficient>
+          <reynolds is_input="False">5475453.978300273<!--reynolds number on the wing in cruise conditions--></reynolds>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.005692465939837433<!--profile drag coefficient for wing in low speed conditions--></CD0>
+          <CDp is_input="False">[0.0014351516081077893, 0.0014477274121616841, 0.0015151516081077893, 0.001577727412161684, 0.0016248483918922109, 0.001807727412161684, 0.0019703032162155785, 0.0021703032162155786, 0.0023828790202694732, 0.002632879020269473, 0.0028954548243233682, 0.0031928790202694736, 0.003505454824323368, 0.003845454824323368, 0.004230606432431157, 0.004673182236485052, 0.005158333844592841, 0.00565348545270063, 0.00613863706080842, 0.0072860612567545256, 0.008746061256754525, 0.010836364472970103, 0.011101366006748627, 0.013349849925670733, 0.01624560796620968, 0.020976973972958307, 0.029139399702682933, 0.04454470752023408, 0.07227289742561174, 0.11136137827697681, 0.006676061256754524, 0.00795863706080842, 0.009658030628377261, 0.010905457891880414, 0.012006364472970104, 0.014593032162155784, 0.01844909341891031, 0.02438788362160504, 0.03568697704051535, 0.05630728945940206, 0.0917304716958871, 0.03807560489865264, 0.03109545482432337, 0.02635924349323958, 0.022924698317562945, 0.01995727412161684, 0.017512122513509053, 0.01544697090540126, 0.013689243493239578, 0.012164091885131786, 0.010848940277023999, 0.009736364472970105, 0.008716667689185682, 0.006836364472970103, 0.006066061256754525, 0.004818333844592841, 0.003800606432431157, 0.0029880306283772626, 0.002375454824323368, 0.0018977274121616838, 0.21474546709455156, 0.19669863706080842, 0.2050153047499941, 0.18747742112838905, 0.001527727412161684, 0.17713136293919157, 0.1668824226621676, 0.07331713631751575, 0.04996469218244885, 0.007718940277023998, 0.0013425758040538948, 0.005400909648646736, 0.004283182236485052, 0.003370606432431157, 0.0026654548243233676, 0.002122879020269473, 0.0016974241959461056, 0.0014251516081077893, 0.0013025758040538945, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--pressure drag coefficient of the wing profile for various angle of attack in low speed conditions--></CDp>
+          <CL is_input="False">[0.07657424195946105, 0.13407424195946108, 0.19132272587838317, 0.24869696783784423, 0.3036848391892211, 0.4131136293919158, 0.46816211331083796, 0.5240136293919159, 0.58001059722976, 0.6352848391892212, 0.6904302909459874, 0.7442015007432927, 0.7969530168243706, 0.8536712097973054, 0.9155212251350906, 0.9789242572972463, 1.0421242572972462, 1.0992272587838317, 1.1452045329054483, 1.2421590811486822, 1.3391333231081433, 1.4282015007432929, 1.5323969371622739, 1.608180275608202, 1.6581166308785011, 1.6911317610137098, 1.7041347931758657, 1.6780923429056847, 1.5803165388517897, 1.4216771820949057, 1.1929590811486823, 1.2913075650676045, 1.3854105972297601, 1.4811332924325729, 1.5733984685811369, 1.6366848085136507, 1.6746848085136508, 1.7017347931758657, 1.6972484225677813, 1.6419059416220299, 1.4991438283111922, -1.31428940277024, -1.3375651454729938, -1.3486439203379033, -1.3478408881757475, -1.3265696783784422, -1.2958984685811368, -1.2594272587838318, -1.2191045329054486, -1.1763560489865266, -1.1325560489865265, -1.0901787748649094, -1.0438984992567073, -0.9211954670945516, -0.8618712097973054, -0.7539015007432928, -0.6479075650676043, -0.5398621133108379, -0.42896514547299375, -0.31636817763514946, -0.8199969371622737, -0.8049939356756884, -0.8141136293919159, -0.7990121286486231, -0.2040681776351495, -0.7979, -0.7983803062837727, -1.1785574883786782, -1.2689000306755707, -0.9829469831756295, -0.09127120979730527, -0.8058787748649094, -0.7015787748649096, -0.5943590811486821, -0.4846393874324547, -0.3727166615540716, -0.25991969371622736, -0.14749393567568844, -0.03507120979730527, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--lift coefficient of the wing profile for various angle of attack in low speed conditions--></CL>
+          <CL0_clean is_input="False">0.08944170718629421<!--wing lift coefficient at zero aircraft angle of attack in low speed conditions and with no flaps deployed--></CL0_clean>
+          <CL_alpha units="1/rad" is_input="False">4.8252079842428275<!--wing lift coefficient slope with respect to aircraft angle of attack in low speed conditions--></CL_alpha>
+          <CL_max_clean is_input="True">1.3528061405111684<!--wing maximum lift coefficient for positive angle of attack--></CL_max_clean>
+          <CL_ref is_input="False">0.9339124208357545</CL_ref>
+          <CL_vector is_input="False">[1.0162730539328482, 1.0146480780555114, 1.0111945007162728, 1.0116250129042759, 1.014870452683793, 1.0153167662222782, 1.0130163822585772, 1.0077208862084366, 0.9989317582744641, 0.985878903053916, 0.9675942949988179, 0.9429750844875814, 0.9090712008042638, 0.8612635115450742, 0.7914145841555678, 0.6831708027767109, 0.49484075768602154, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--lift coefficient of the wing at the station along the wing span in Y_vector, the total corresponding wing lift coefficient is equal to CL0_clean--></CL_vector>
+          <CM0_clean is_input="False">-0.020582122089420705<!--wing pitching moment coefficient in low speed conditions and with no flaps deployed--></CM0_clean>
+          <Y_vector units="m" is_input="False">[0.172978365452862, 0.518935096358586, 0.86489182726431, 1.2573659242803215, 1.6963573874066202, 2.1353488505329192, 2.574340313659218, 3.013331776785516, 3.4523232399118147, 3.8913147030381134, 4.313421879121094, 4.718644768160754, 5.123867657200414, 5.529090546240074, 5.934313435279734, 6.339536324319394, 6.744759213359056, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--wing station along the wing span at which chord_vector and Cl_vector are sampled--></Y_vector>
+          <chord_vector units="m" is_input="False">[1.7974143073359936, 1.7974143073359936, 1.7974143073359936, 1.784729697795651, 1.7593604787149655, 1.7339912596342806, 1.7086220405535955, 1.6832528214729103, 1.6578836023922254, 1.6325143833115399, 1.6081209034262658, 1.5847031627364025, 1.5612854220465395, 1.537867681356676, 1.5144499406668128, 1.4910321999769496, 1.4676144592870863, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--wing chord length at the station along the wing span in Y_vector--></chord_vector>
+          <induced_drag_coefficient is_input="False">0.04847206312472919<!--coefficient to multiply by the lift coefficient squared to get wing induced drag in low speed conditions--></induced_drag_coefficient>
+          <reynolds is_input="False">4557580.953491815<!--reynolds number on the wing in low speed conditions--></reynolds>
+        </low_speed>
+        <MAC>
+          <low_speed>
+            <reynolds is_input="False">4557580.953491815<!--wing reynolds number in low speed conditions at the mean aerodynamic chord--></reynolds>
+          </low_speed>
+        </MAC>
+      </wing>
+      <aircraft>
+        <cruise>
+          <CD0 is_input="False">0.02621193101160031<!--profile drag coefficient for the complete aircraft in cruise conditions--></CD0>
+          <Cn_beta units="1/rad" is_input="False">0.051021126335264524</Cn_beta>
+          <Cy_beta units="1/rad" is_input="False">-0.5294761956456046</Cy_beta>
+          <L_D_max is_input="False">13.883089341134193<!--profile drag coefficient for the complete aircraft in low speed conditions--></L_D_max>
+          <optimal_CD is_input="False">0.052423862023200624<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
+          <optimal_CL is_input="False">0.7278051600753862<!--lift coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CL>
+          <optimal_alpha units="deg" is_input="False">7.485714590189957<!--wing angle of attack at maximum lift/drag ratio in cruise conditions--></optimal_alpha>
+        </cruise>
+        <landing>
+          <CL_max is_input="False">2.2228061405111683<!--maximum lift coefficient at landing--></CL_max>
+        </landing>
+        <low_speed>
+          <CD0 is_input="False">0.026893627690706412<!--profile drag coefficient for the complete aircraft in low speed conditions--></CD0>
+          <Cn_beta units="1/rad" is_input="False">0.05124585491509649</Cn_beta>
+          <Cy_beta units="1/rad" is_input="False">-0.5265612535257456</Cy_beta>
+        </low_speed>
+        <mach_interpolation>
+          <CL_alpha_vector units="1/rad" is_input="False">[5.4712048525620665, 5.4845499134281805, 5.524965560305344, 5.593619323992968, 5.692547360245432, 5.824801389623059]<!--lift curve slope coefficients of the aircraft at the mach number given in mach_vector--></CL_alpha_vector>
+          <mach_vector is_input="False">[0.0, 0.0582765373529396, 0.1165530747058792, 0.1748296120588188, 0.2331061494117584, 0.291382686764698]<!--mach numbers at which the aircraft lift curve slope in CL_alpha_vector was computed--></mach_vector>
+        </mach_interpolation>
+        <takeoff>
+          <CL_max is_input="False">1.6898061405111684<!--maximum lift coefficient during take-off--></CL_max>
+        </takeoff>
+      </aircraft>
+      <cooling>
+        <cruise>
+          <CD0 is_input="True">0.004<!--profile drag due to cooling in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="True">0.004<!--profile drag due to cooling in low speed conditions--></CD0>
+        </low_speed>
+      </cooling>
+      <elevator>
+        <low_speed>
+          <CD_delta units="1/rad**2" is_input="False">0.07711753031524064<!--derivative of horizontal tail drag coefficient with respect to elevator command--></CD_delta>
+          <CL_delta units="1/rad" is_input="False">0.7490764048973457<!--derivative of horizontal tail lift coefficient with respect to elevator command--></CL_delta>
+        </low_speed>
+      </elevator>
+      <flaps>
+        <landing>
+          <CD_2D is_input="True">0.0<!--lift coefficient increment due to flaps deployment in landing configuration--></CD_2D>
+          <CL_2D is_input="True">1.3<!--lift coefficient increment due to flaps deployment in landing configuration--></CL_2D>
+          <CM_2D is_input="True">-0.01<!--lift coefficient increment due to flaps deployment in landing configuration--></CM_2D>
+          <CL is_input="True">1.0<!--lift coefficient increment due to flaps deployment in landing configuration--></CL>
+          <CD is_input="True">0.0<!--lift coefficient increment due to flaps deployment in landing configuration--></CD>
+          <CL_max is_input="True">0.87<!--maximum lift coefficient increment due to flaps deployment in landing configuration--></CL_max>
+          <CM is_input="True">-0.14648012559668536<!--additional pitching moment coefficient ue to the deployment of flaps in landing configuration--></CM>
+        </landing>
+        <takeoff>
+          <CL is_input="True">0.5<!--lift coefficient increment due to flaps deployment in takeoff configuration--></CL>
+          <CL_max is_input="True">0.337<!--maximum lift coefficient increment due to flaps deployment in takeoff configuration--></CL_max>
+          <CM is_input="True">-0.04448449127122522<!--additional pitching moment coefficient due to the deployment of flaps in takeoff configuration--></CM>
+        </takeoff>
+      </flaps>
+      <landing_gear>
+        <cruise>
+          <CD0 is_input="False">0.001700269922150688<!--profile drag coefficient for landing gears in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.001700269922150688<!--profile drag coefficient for landing gears in low speed conditions--></CD0>
+        </low_speed>
+      </landing_gear>
+      <nacelles>
+        <cruise>
+          <CD0 is_input="False">0.0<!--profile drag coefficient for the nacelles in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.0<!--profile drag coefficient for the nacelles in low speed conditions--></CD0>
+        </low_speed>
+      </nacelles>
+      <other>
+        <cruise>
+          <CD0 is_input="False">0.006265157517510828<!--profile drag coefficient for other systems in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="False">0.006265157517510828<!--profile drag coefficient for other systems in low speed conditions--></CD0>
+        </low_speed>
+      </other>
+      <propeller>
+        <cruise_level>
+          <altitude units="m" is_input="True">8534.4<!--altitude at which the cruise level propeller efficiency map was computed--></altitude>
+          <efficiency is_input="True">[[0.14164876718665512, 0.15960486139273003, 0.15315546527521565, 0.14106516538169464, 0.12900594711813504, 0.11852554486382955, 0.10879739455828018, 0.10004087217528933, 0.09198496503114272, 0.08527898190119572, 0.07886608243388141, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972, 0.07244878647399972], [0.5055369438988795, 0.5577646347461669, 0.5486760681089059, 0.5236390291769096, 0.49530578589534735, 0.467887508450272, 0.44333148813437073, 0.4183864379036675, 0.39521798798948676, 0.37261179258190164, 0.35302402703076413, 0.33530101815878344, 0.31644753740991466, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856, 0.3051044964076856], [0.647719510630279, 0.7044586315779496, 0.7063716846972413, 0.6896546056782482, 0.667102450595981, 0.6430369264054759, 0.6208470531904912, 0.5978999833396265, 0.5745018164590019, 0.5521507803072513, 0.529259178914271, 0.5085436791505601, 0.48992416982074855, 0.4714268862177383, 0.44699964949334964, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524, 0.4389085528128524], [0.6904738980362004, 0.7536210855767603, 0.7672134604378817, 0.7613192715515598, 0.7477851294226329, 0.7311356894709377, 0.7139156695069723, 0.6969260762524644, 0.6781847072022253, 0.6590157484592853, 0.6402256343883909, 0.6207084174696489, 0.6020314927104461, 0.5850993584856281, 0.5685556023397138, 0.5502980314854538, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297, 0.5271121123678297], [0.6734690322987056, 0.7622584843496828, 0.7881798527237751, 0.7923400452974934, 0.7867555634232994, 0.7770122132130838, 0.765551023038805, 0.7533520198444158, 0.7395842266884675, 0.7248531697275146, 0.7096389018380802, 0.6940540053390071, 0.6779114845360092, 0.662156981580546, 0.6471102858851263, 0.6326555635315946, 0.6176609085962129, 0.5986248189532736, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142, 0.5868127103611142], [0.665461397229054, 0.7582933387108498, 0.7920692207284183, 0.8039813803325424, 0.8055548245967594, 0.8016879764340723, 0.7949518541695533, 0.7868828997022362, 0.7774039603103458, 0.7665797711498789, 0.7549045795377125, 0.742756616885738, 0.7299747936038211, 0.7165169332244656, 0.7031338598020891, 0.6900601804735936, 0.677264512166526, 0.6644401754415459, 0.650411634382524, 0.6297289528845891, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943, 0.6133262069032943], [0.6120416717461665, 0.7362226576143458, 0.7838215770718068, 0.8045817651686856, 0.8127635139460893, 0.814151398435821, 0.8115716766805092, 0.8069777924261983, 0.8009714646677633, 0.7935060066049995, 0.7849364512719507, 0.7755632764922957, 0.7656803935032948, 0.7552482448758505, 0.7439503363812875, 0.7324894204096599, 0.721047795012013, 0.7097018284631843, 0.6983572342554676, 0.6867178091974014, 0.6733893224805284, 0.6427633297871449, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941, 0.6364232331830941], [0.5681907977710996, 0.717833235019142, 0.7736999915995015, 0.7973626605180325, 0.8110428736480053, 0.8174009480832755, 0.818838790260095, 0.8169218856756644, 0.813706060492747, 0.809316100384316, 0.803788336605835, 0.7971542188764664, 0.7896716644110521, 0.781583582799063, 0.7730647106887419, 0.7638007911685946, 0.7539547645490383, 0.7438807604580127, 0.7337553380538386, 0.7235628807281755, 0.7132515340871315, 0.7025750634889955, 0.6902512270215989, 0.6702954891662807, 0.6503916184566132, 0.6503916184566132, 0.6503916184566132, 0.6503916184566132, 0.6503916184566132, 0.6503916184566132], [0.5368322846976181, 0.6790133419734296, 0.7424637917583204, 0.7813579363945153, 0.7984092813510888, 0.8092533965259407, 0.8154349718215954, 0.8164307101012881, 0.8159333428776044, 0.8139572500824466, 0.810822671791745, 0.806844335038797, 0.8021009910335557, 0.7965969259747216, 0.7903850998299972, 0.7836138973273817, 0.7763483560747192, 0.7685363069773893, 0.7597996322447216, 0.7508053515399739, 0.7416164113111879, 0.7320745861418012, 0.7224489380637406, 0.7125613168338941, 0.701594308432526, 0.6855940199215238, 0.6651280717973818, 0.6651280717973818, 0.6651280717973818, 0.6651280717973818], [0.4914286163747157, 0.5908831457128332, 0.6903376750509507, 0.7258435047503502, 0.7594415435449474, 0.7734726841035194, 0.7867874640542092, 0.7920759343154029, 0.7965661367539547, 0.7974260299200695, 0.7973853975325182, 0.7957671450770302, 0.7933205612196066, 0.7903433643720974, 0.7869579506449694, 0.7832402368469255, 0.7788279187156112, 0.7734674046371597, 0.7676548288328013, 0.7614836696311569, 0.7547587340584712, 0.7473221508030389, 0.738882429302868, 0.7295811426587137, 0.7206013418550254, 0.7111121808872467, 0.7009656306348119, 0.6901129303878953, 0.6766197094574787, 0.6300290107452673]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at cruise level--></efficiency>
+          <speed units="m/s" is_input="True">[5.0, 26.394074074074076, 47.78814814814815, 69.18222222222224, 90.5762962962963, 111.97037037037038, 133.36444444444447, 154.75851851851854, 176.1525925925926, 197.54666666666668]<!--speed at which the efficiencies of the propeller at cruise level are computed--></speed>
+          <thrust units="N" is_input="True">[604.0854711372201, 1058.858378799996, 1513.6312864627716, 1968.4041941255475, 2423.1771017883234, 2877.9500094510995, 3332.722917113875, 3787.495824776651, 4242.2687324394265, 4697.041640102202, 5151.814547764979, 5606.587455427754, 6061.36036309053, 6516.133270753306, 6970.906178416082, 7425.679086078858, 7880.4519937416335, 8335.224901404408, 8789.997809067185, 9244.77071672996, 9699.543624392736, 10154.31653205551, 10609.089439718287, 11063.862347381064, 11518.635255043839, 11973.408162706615, 12428.18107036939, 12882.953978032167, 13337.726885694943, 13792.499793357718]<!--thrust produced by the propeller at cruise level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="True">[5439.352167977612, 6249.242938058488, 7050.701857154905, 7763.933686939635, 8493.044280368791, 9291.52006415447, 10164.968044886155, 11112.078491633858, 12149.187683872855, 13792.499793357718]<!--maximum thrust output of the propeller at cruise level for varying velocities--></thrust_limit>
+        </cruise_level>
+        <installation_effect>
+          <effective_advance_ratio is_input="False">0.9152494289169578<!--Value to multiply the flight advance ration with to obtain the effective advance ratio due to the presence of cowling (fuselage or nacelle) behind the propeller--></effective_advance_ratio>
+          <effective_efficiency>
+            <cruise is_input="False">0.978494814687053<!--Value to multiply the uninstalled efficiency with to obtain the effective efficiency due to the presence of cowling (fuselage or nacelle) behind the propeller--></cruise>
+            <low_speed is_input="False">0.9698147444862564<!--Value to multiply the uninstalled efficiency with to obtain the effective efficiency due to the presence of cowling (fuselage or nacelle) behind the propeller--></low_speed>
+          </effective_efficiency>
+        </installation_effect>
+        <sea_level>
+          <efficiency is_input="True">[[0.12170551156424486, 0.16460125658230276, 0.1636267238284427, 0.15182556789611049, 0.13881583653644597, 0.1270589560149405, 0.11693500491867963, 0.10754532609560111, 0.09926009544114987, 0.0916795073932129, 0.08539578726898711, 0.07925271138429565, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497, 0.07355002320887497], [0.4561765654895388, 0.5687390173301192, 0.5723379879808577, 0.5496385939418656, 0.5207474957317817, 0.4918481665891808, 0.46550874876618376, 0.4406105636055726, 0.41662671429283193, 0.39434445637576515, 0.37273132642292994, 0.35447040376376626, 0.3375419983288415, 0.3196379554550547, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134, 0.30869016428452134], [0.6041398835048051, 0.7116504547128948, 0.7255442153781843, 0.7124285955131641, 0.6905850992835235, 0.6662780690222526, 0.6424000021721474, 0.6202646785570419, 0.5969274974309231, 0.5743181996071305, 0.5527648893165913, 0.5307508709251779, 0.5114261687663602, 0.49358966439055024, 0.4759485328047712, 0.4540993460116285, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555, 0.44421022729630555], [0.618594647349154, 0.7551544338072292, 0.7807483314785894, 0.778246344323533, 0.7665569351299256, 0.750430220344711, 0.7329192522724481, 0.715724682251733, 0.6979023309122322, 0.679082311742029, 0.660527518344406, 0.6421276577271844, 0.6234566012773199, 0.6059323978822686, 0.5897858883581767, 0.5739756513810015, 0.5570145363509246, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408, 0.5334223799053408], [0.6354336046743954, 0.7598480261250503, 0.7958906561875122, 0.8044392495359134, 0.8014442663802328, 0.7929106086352125, 0.7817304553760206, 0.7695537098052677, 0.7563804268708595, 0.7421544666308162, 0.7273788720144163, 0.7124369251618948, 0.6971302658188632, 0.6817177175204744, 0.6668107319752077, 0.6525380760303593, 0.6387213880682887, 0.6245769549336243, 0.6079975575745334, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593, 0.593899096773593], [0.5431450149582921, 0.7420623333528972, 0.7951086237570346, 0.8134611700742327, 0.8178544955864474, 0.8153945065893419, 0.809422309738839, 0.8016782004996675, 0.7924929210040703, 0.7820101265227921, 0.7706833506367073, 0.7588795499781376, 0.7467170463177807, 0.7340209988571709, 0.7211662621385144, 0.7084841023298188, 0.6960984886879061, 0.6839153611276951, 0.6717639882489759, 0.6588210702492646, 0.6419566951338875, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132, 0.6235278678241132], [0.5158566728155526, 0.7286854793486797, 0.7916509932980151, 0.8166088591277336, 0.8254171082207148, 0.827581753913289, 0.8257076030254143, 0.8214706263966547, 0.8156007136348594, 0.8082934943224086, 0.7998351888366997, 0.7906804878611988, 0.7810564709628447, 0.7710109248700554, 0.7604160925149416, 0.7495042940343922, 0.7386086189095609, 0.727772592192979, 0.7170006553935464, 0.7062274702277647, 0.695291654395464, 0.683293476773961, 0.666469028616552, 0.6487807343134597, 0.6487807343134597, 0.6487807343134597, 0.6487807343134597, 0.6487807343134597, 0.6487807343134597, 0.6487807343134597], [0.5096400915116762, 0.720489787757189, 0.7777714175100056, 0.8110236635023377, 0.8273703236750343, 0.8340132348734484, 0.8349472658463051, 0.8335556992878399, 0.8304044484275337, 0.8259097815982588, 0.8198506058554059, 0.8128575180088459, 0.8053028083291262, 0.7973243057246986, 0.7889411115570013, 0.7800626199665032, 0.770677428195441, 0.761142565876622, 0.7515895651976898, 0.742022068775327, 0.7323829230850438, 0.7226547659500948, 0.7127047601359988, 0.7016170741617288, 0.686383739809833, 0.6661533376205229, 0.6661533376205229, 0.6661533376205229, 0.6661533376205229, 0.6661533376205229], [0.5088613240616686, 0.6717787177105687, 0.7647283977484555, 0.8078170955800997, 0.8234068777674834, 0.834318089643936, 0.8393826278080847, 0.8398795774195602, 0.8389398706437069, 0.8366112641198606, 0.8326584042995884, 0.8278781604952046, 0.8223132850314743, 0.8159876545999083, 0.8092317598805292, 0.8021702817856472, 0.7947500424763607, 0.7868121040061546, 0.7784040247317462, 0.7698628754676751, 0.7612828332826885, 0.7526071229214566, 0.7437990328052992, 0.7348757265522391, 0.7257828452487639, 0.7157284384493894, 0.7028921413971948, 0.6776662891061521, 0.6776662891061521, 0.6776662891061521], [0.5081363796183407, 0.6371680215497285, 0.7541024069544995, 0.7886552123411088, 0.816703599879111, 0.8290554141327382, 0.8371396739337617, 0.8409163638489959, 0.8416414423300669, 0.8412463313056332, 0.8389743767446378, 0.8361827275955567, 0.8325386129847724, 0.8279758104941563, 0.8229632689508231, 0.8172852080753216, 0.8113045567032511, 0.8050944150388317, 0.798567545388568, 0.791392106108866, 0.7838793775580073, 0.7761192208130805, 0.768203522016934, 0.7602605313923945, 0.7520909925109382, 0.7437487762124398, 0.7353698721925668, 0.7264345782996826, 0.715314381600052, 0.6943822207499107]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at sea level--></efficiency>
+          <speed units="m/s" is_input="True">[5.0, 26.394074074074076, 47.78814814814815, 69.18222222222224, 90.5762962962963, 111.97037037037038, 133.36444444444447, 154.75851851851854, 176.1525925925926, 197.54666666666668]<!--speed at which the efficiencies of the propeller at sea level are computed--></speed>
+          <thrust units="N" is_input="True">[959.3144390294647, 2037.1397324852558, 3114.965025941047, 4192.790319396838, 5270.615612852629, 6348.44090630842, 7426.266199764211, 8504.091493220003, 9581.916786675793, 10659.742080131586, 11737.567373587375, 12815.392667043168, 13893.217960498958, 14971.043253954747, 16048.86854741054, 17126.69384086633, 18204.519134322123, 19282.344427777913, 20360.169721233706, 21437.995014689495, 22515.82030814529, 23593.645601601078, 24671.47089505687, 25749.29618851266, 26827.12148196845, 27904.946775424243, 28982.772068880033, 30060.597362335826, 31138.422655791615, 32216.24794924741]<!--thrust produced by the propeller at sea level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="True">[13454.237385926104, 15445.882318378934, 17409.231650734866, 19144.60063477435, 20908.399410396873, 22846.805178623505, 24942.022016881194, 27197.519899543593, 29609.080280991373, 32216.24794924741]<!--maximum thrust output of the propeller at sea level for varying velocities--></thrust_limit>
+        </sea_level>
+      </propeller>
+      <rudder>
+        <cruise>
+          <Cy_delta_r units="1/rad" is_input="False">1.8149047841704655<!--derivative of the side force coefficient with respect to the rudder command in cruise conditions--></Cy_delta_r>
+        </cruise>
+        <low_speed>
+          <Cy_delta_r units="1/rad" is_input="False">1.7960910757911606<!--derivative of the side force coefficient with respect to the rudder command in low speed conditions--></Cy_delta_r>
+        </low_speed>
+      </rudder>
+    </aerodynamics>
+    <constraints>
+      <horizontal_tail>
+        <landing units="m**2" is_input="False">0.6303942987502218<!--margin on the horizontal tail area with respect to the landing constraint--></landing>
+        <takeoff_rotation units="m**2" is_input="False">0.0<!--margin on the horizontal tail area with respect to the takeoff rotation constraint--></takeoff_rotation>
+      </horizontal_tail>
+      <vertical_tail>
+        <crosswind_landing units="m**2" is_input="False">-2.178257574314557e-12<!--margin on the vertical tail area with respect to the constraint due to crosswind landing--></crosswind_landing>
+        <engine_out_climb units="m**2" is_input="False">2.836529663074388<!--margin on the vertical tail area with respect to the climb with one engine out condition--></engine_out_climb>
+        <engine_out_landing units="m**2" is_input="False">2.836529663074388<!--margin on the vertical tail area with respect to the landing with one engine out condition--></engine_out_landing>
+        <engine_out_takeoff units="m**2" is_input="False">2.836529663074388<!--margin on the vertical tail area with respect to the takeoff with one engine out condition--></engine_out_takeoff>
+        <target_cruise_stability units="m**2" is_input="False">0.585656580195757<!--margin on the vertical tail area with respect to the cruise stability constraint--></target_cruise_stability>
+      </vertical_tail>
+      <wing>
+        <additional_CL_capacity is_input="False">0.0<!--margin with respect to the conditions of maximum lift required--></additional_CL_capacity>
+        <additional_fuel_capacity units="kg" is_input="False">520.7745734294924<!--margin with respect to the conditions of maximum fuel stored in the wing required--></additional_fuel_capacity>
+      </wing>
+    </constraints>
+    <mission>
+      <sizing>
+        <duration units="s" is_input="False">37606.85657861986</duration>
+        <energy units="W*h" is_input="False">0.0</energy>
+        <fuel units="kg" is_input="False">932.1783077197445</fuel>
+        <initial_climb>
+          <energy units="W*h" is_input="True">0.0</energy>
+          <fuel units="kg" is_input="True">0.3</fuel>
+        </initial_climb>
+        <landing>
+          <elevator_angle units="rad" is_input="True">-0.5235987755982988<!--position of the elevator during landing--></elevator_angle>
+          <target_sideslip units="deg" is_input="True">18.0</target_sideslip>
+        </landing>
+        <takeoff>
+          <elevator_angle units="rad" is_input="True">-0.5235987755982988<!--position of the elevator during takeoff--></elevator_angle>
+          <energy units="W*h" is_input="True">0.0</energy>
+          <fuel units="kg" is_input="True">15.0</fuel>
+          <thrust_rate is_input="True">1.0<!--thrust rate during takeoff phase--></thrust_rate>
+        </takeoff>
+        <taxi_in>
+          <duration units="s" is_input="True">300.0<!--duration of taxi in phase--></duration>
+          <energy units="W*h" is_input="False">0.0</energy>
+          <fuel units="kg" is_input="False">4.765504580770602</fuel>
+          <speed units="m/s" is_input="True">10.28888888888889<!--ground velocity during taxi in phase--></speed>
+          <thrust units="N" is_input="False">485.96112311015116</thrust>
+        </taxi_in>
+        <taxi_out>
+          <duration units="s" is_input="True">300.0<!--duration of taxi out phase--></duration>
+          <energy units="W*h" is_input="False">0.0</energy>
+          <fuel units="kg" is_input="False">4.765504580770602</fuel>
+          <speed units="m/s" is_input="True">10.28888888888889<!--ground velocity during taxi out phase--></speed>
+          <thrust units="N" is_input="False">485.96112311015116</thrust>
+        </taxi_out>
+        <cs23>
+          <characteristic_speed>
+            <vd units="m/s" is_input="True">93.6288888888889<!--limit speed--></vd>
+          </characteristic_speed>
+          <sizing_factor>
+            <ultimate_aircraft is_input="True">6.4<!--ultimate load factor that the aircraft will experience (default value is 5.7)--></ultimate_aircraft>
+          </sizing_factor>
+        </cs23>
+        <main_route>
+          <climb>
+            <distance units="m" is_input="False">92123.1876051973</distance>
+            <duration units="s" is_input="False">1536.8073268760352</duration>
+            <energy units="W*h" is_input="False">0.0</energy>
+            <fuel units="kg" is_input="False">22.859364440272184</fuel>
+            <v_eas units="m/s" is_input="True">51.95888888888889</v_eas>
+            <climb_rate>
+              <cruise_level units="m/s" is_input="True">5.09016<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="m/s" is_input="True">7.8486<!--target climb rate at sea level--></sea_level>
+            </climb_rate>
+          </climb>
+          <cruise>
+            <altitude units="ft" is_input="True">10000.0<!--main route cruise phase altitude--></altitude>
+            <distance units="m" is_input="False">1960036.3738076522</distance>
+            <duration units="s" is_input="False">31750.049251743825</duration>
+            <energy units="W*h" is_input="False">0.0</energy>
+            <fuel units="kg" is_input="False">798.2646268847952</fuel>
+          </cruise>
+          <descent>
+            <descent_rate units="m/s" is_input="True">-4.064<!--target descent rate for the aircraft--></descent_rate>
+            <distance units="m" is_input="False">83111.35388124874</distance>
+            <duration units="s" is_input="False">1020.0</duration>
+            <energy units="W*h" is_input="False">0.0</energy>
+            <fuel units="kg" is_input="False">22.845930741989537</fuel>
+            <v_eas units="m/s" is_input="True">82.31111111111112</v_eas>
+          </descent>
+          <reserve>
+            <altitude units="m" is_input="True">3048.0</altitude>
+            <duration units="s" is_input="True">2700.0<!--duration of the reserve segment--></duration>
+            <energy units="W*h" is_input="False">0.0</energy>
+            <fuel units="kg" is_input="False">63.377376491146265</fuel>
+            <v_tas units="m/s" is_input="False">61.41820479295698</v_tas>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+    <weight>
+      <aircraft>
+        <MFW units="kg" is_input="False">1444.859580399219<!--maximum fuel weight--></MFW>
+        <MLW units="kg" is_input="False">3047.644393009553<!--maximum landing weight--></MLW>
+        <MTOW units="kg" is_input="False">3279.200314313868<!--maximum takeoff weight of the aircraft--></MTOW>
+        <MZFW units="kg" is_input="False">2867.0220065941235<!--maximum zero fuel weight--></MZFW>
+        <OWE units="kg" is_input="False">1727.0220065941235<!--Mass of aircraft--></OWE>
+        <ZFW units="kg" is_input="False">2347.0220065941235<!--aircraft mass with payload, without fuel--></ZFW>
+        <max_payload units="kg" is_input="True">1140.0<!--max payload weight--></max_payload>
+        <payload units="kg" is_input="True">620.0<!--design payload weight--></payload>
+        <CG>
+          <aft>
+            <MAC_limit units="m" is_input="True">0.16<!--position of the aft limit of the Weight and balance envelop as a percent of MAC--></MAC_limit>
+            <MAC_position is_input="False">0.4374411676005473<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
+            <x units="m" is_input="False">4.358824448982134<!--most aft X-position of aircraft center of gravity--></x>
+          </aft>
+          <fwd>
+            <MAC_limit units="m" is_input="True">0.1<!--position of the fwd limit of the Weight and balance envelop as a percent of MAC--></MAC_limit>
+            <MAC_position is_input="False">0.1774411676005473<!--most fwd X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
+            <x units="m" is_input="False">3.9274551326832032<!--most fwd X-position of center of gravity--></x>
+          </fwd>
+          <flight_condition>
+            <max>
+              <MAC_position is_input="False">0.4374411676005473<!--most aft position of the CG with respect to the mean aerodynamic chord based on all possible flight loading case--></MAC_position>
+            </max>
+            <min>
+              <MAC_position is_input="False">0.17744116760054732<!--most fwd position of the CG with respect to the mean aerodynamic chord based on all possible flight loading case--></MAC_position>
+            </min>
+          </flight_condition>
+          <ground_condition>
+            <max>
+              <MAC_position is_input="False">0.42432031138323245<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord for ground conditions--></MAC_position>
+            </max>
+            <min>
+              <MAC_position is_input="False">0.24731793111460634<!--most fwd X-position of center of gravity as ratio of mean aerodynamic chord for ground conditions--></MAC_position>
+            </min>
+          </ground_condition>
+        </CG>
+        <empty>
+          <CG>
+            <MAC_position is_input="False">0.2774411676005473<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
+          </CG>
+        </empty>
+        <in_flight_variation>
+          <fixed_mass_comp>
+            <equivalent_moment units="kg*m" is_input="False">9122.384868090694</equivalent_moment>
+            <mass units="kg" is_input="False">2290.496649022518</mass>
+          </fixed_mass_comp>
+        </in_flight_variation>
+      </aircraft>
+      <aircraft_empty>
+        <mass units="kg" is_input="False">1670.4966490225177<!--mass of empty aircraft--></mass>
+        <CG>
+          <x units="m" is_input="False">4.093366408182792<!--X-position center of gravity of empty aircraft--></x>
+          <z units="m" is_input="False">1.4637713101254757<!--Z-position center of gravity of empty aircraft--></z>
+        </CG>
+      </aircraft_empty>
+      <airframe>
+        <mass units="kg" is_input="False">972.4568483570016<!--Mass of the airframe--></mass>
+        <flight_controls>
+          <mass units="lbm" is_input="False">102.66439698067614<!--Mass of the airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">6.577838417004744<!--X-position of center of gravity of the flight controls--></x>
+          </CG>
+        </flight_controls>
+        <fuselage>
+          <mass units="lbm" is_input="False">842.7563738884987<!--Mass of the airframe_inp_data:weight:airframe:fuselage:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">5.1<!--X-position of center of gravity of the fuselage--></x>
+          </CG>
+        </fuselage>
+        <horizontal_tail>
+          <k_factor is_input="True">1.0<!--proportional corrective factor for horizontal tail mass--></k_factor>
+          <mass units="lbm" is_input="False">87.23583264150095<!--Mass of the airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">9.359207166256038<!--X-position of center of gravity of the horizontal tail--></x>
+          </CG>
+        </horizontal_tail>
+        <paint>
+          <mass units="kg" is_input="False">30.23535757160567<!--Mass of the airframe_inp_data:weight:airframe:paint:mass--></mass>
+        </paint>
+        <vertical_tail>
+          <k_factor is_input="True">1.0<!--proportional corrective factor for vertical tail mass--></k_factor>
+          <mass units="lbm" is_input="False">47.00690345882125<!--Mass of the airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">9.125100390071527<!--X-position of center of gravity of the vertical tail--></x>
+          </CG>
+        </vertical_tail>
+        <wing>
+          <k_factor is_input="True">1.0<!--proportional corrective factor for wing mass--></k_factor>
+          <mass units="lbm" is_input="False">749.0046109033312<!--Mass of the airframe_inp_data:weight:airframe:wing:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">4.30679834084563<!--X-position of center of gravity of the wing--></x>
+          </CG>
+          <distributed_mass>
+            <chord_slope is_input="False">[]</chord_slope>
+            <mass units="kg" is_input="False">[]</mass>
+            <start_chord units="m" is_input="False">[]</start_chord>
+            <y_ratio_end is_input="False">[]</y_ratio_end>
+            <y_ratio_start is_input="False">[]</y_ratio_start>
+          </distributed_mass>
+          <distributed_tanks>
+            <chord_slope is_input="False">0.0</chord_slope>
+            <fuel_inside units="kg" is_input="False">461.39691955329334</fuel_inside>
+            <start_chord units="m" is_input="False">1.6352440410463565</start_chord>
+            <y_ratio_end is_input="False">0.523367728001997</y_ratio_end>
+            <y_ratio_start is_input="False">0.206632271998003</y_ratio_start>
+          </distributed_tanks>
+          <punctual_mass>
+            <mass units="kg" is_input="False">[]<!--mass of the punctual masses on the wing used for wing load computation--></mass>
+            <y_ratio is_input="False">[]<!--position (as a percent of wing semi-span) of the punctual masses on the wing used for wing load computation, only positive ratio will be considered--></y_ratio>
+          </punctual_mass>
+          <punctual_tanks>
+            <fuel_inside units="kg" is_input="False">[]</fuel_inside>
+            <y_ratio is_input="False">[]</y_ratio>
+          </punctual_tanks>
+        </wing>
+        <landing_gear>
+          <front>
+            <mass units="lbm" is_input="False">64.15374762827942<!--Mass of the airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">1.7249999999999999<!--X-position of center of gravity of the front landing gear--></x>
+            </CG>
+          </front>
+          <main>
+            <mass units="lbm" is_input="False">184.42094787645394<!--Mass of the airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">5.190558485486801<!--X-position of center of gravity of the main landing gear--></x>
+            </CG>
+          </main>
+        </landing_gear>
+      </airframe>
+      <furniture>
+        <mass units="kg" is_input="False">160.0<!--Mass of aircraft furniture--></mass>
+        <passenger_seats>
+          <mass units="kg" is_input="True">160.0<!--Mass of aircraft furniture_inp_data:weight:furniture:passenger_seats:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">5.6000000000000005<!--X-position of center of gravity of the passenger/pilot seats--></x>
+          </CG>
+        </passenger_seats>
+      </furniture>
+      <propulsion>
+        <mass units="kg" is_input="False">319.08967613712184<!--Mass of aircraft_inp_data:weight:propulsion:mass--></mass>
+        <CG>
+          <x units="m" is_input="False">1.211921758015646</x>
+        </CG>
+        <engine>
+          <mass units="kg" is_input="True">332.73828672359406<!--total engine mass--></mass>
+          <CG>
+            <z units="m" is_input="False">1.45<!--Z-position of center of gravity of the engine(s)--></z>
+          </CG>
+        </engine>
+        <fuel_lines>
+          <mass units="kg" is_input="True">39.114300779223676<!--fuel lines mass--></mass>
+        </fuel_lines>
+        <unusable_fuel>
+          <mass units="kg" is_input="True">43.60019550590331<!--total unusable fuel mass--></mass>
+        </unusable_fuel>
+        <tank>
+          <CG>
+            <x units="m" is_input="False">4.047838417004744<!--X-position of center of gravity of the tank--></x>
+          </CG>
+        </tank>
+      </propulsion>
+      <systems>
+        <mass units="kg" is_input="False">275.4754821<!--Mass of aircraft systems--></mass>
+        <avionics>
+          <mass units="lbm" is_input="False">330.0<!--Mass of aircraft systems_inp_data:weight:systems:avionics:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">2.65<!--X-position of center of gravity of the navigation system--></x>
+          </CG>
+        </avionics>
+        <recording>
+          <mass units="kg" is_input="True">3.5<!--Mass of aircraft systems_inp_data:weight:systems:recording:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">8.419999999999998</x>
+          </CG>
+        </recording>
+        <life_support>
+          <air_conditioning>
+            <mass units="kg" is_input="True">30.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:air_conditioning:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">2.3<!--X-position of center of gravity of the air conditioning--></x>
+            </CG>
+          </air_conditioning>
+          <de_icing>
+            <mass units="kg" is_input="True">0.72<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de_icing:mass--></mass>
+          </de_icing>
+          <fixed_oxygen>
+            <mass units="kg" is_input="True">19.7<!--Mass of aircraft systems_inp_data:weight:systems:life_support:fixed_oxygen:mass--></mass>
+          </fixed_oxygen>
+          <insulation>
+            <mass units="kg" is_input="True">4.17<!--Mass of aircraft systems_inp_data:weight:systems:life_support:insulation:mass--></mass>
+          </insulation>
+          <internal_lighting>
+            <mass units="kg" is_input="True">1.7<!--Mass of aircraft systems_inp_data:weight:systems:life_support:internal_lighting:mass--></mass>
+          </internal_lighting>
+          <seat_installation>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:seat_installation:mass--></mass>
+          </seat_installation>
+          <security_kits>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:security_kits:mass--></mass>
+          </security_kits>
+        </life_support>
+        <power>
+          <electric_systems>
+            <mass units="kg" is_input="True">66.0<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">4.42<!--X-position of center of gravity of the electric power unit--></x>
+            </CG>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">4.42<!--X-position of center of gravity of the hydraulic power unit--></x>
+            </CG>
+          </hydraulic_systems>
+        </power>
+      </systems>
+      <payload>
+        <PAX>
+          <CG>
+            <x units="m" is_input="False">5.6000000000000005<!--X-position of center of gravity of the passengers/pilots--></x>
+          </CG>
+        </PAX>
+        <front_fret>
+          <CG>
+            <x units="m" is_input="False">0.0<!--X-position of center of gravity of the front fret--></x>
+          </CG>
+        </front_fret>
+        <rear_fret>
+          <CG>
+            <x units="m" is_input="False">7.135<!--X-position of center of gravity of the rear fret--></x>
+          </CG>
+        </rear_fret>
+      </payload>
+    </weight>
+    <environmental_impact>
+      <operation>
+        <sizing>
+          <he_power_train>
+            <turboshaft>
+              <turboshaft_1>
+                <CO units="g" is_input="False">4584.391538598723</CO>
+                <CO2 units="g" is_input="False">2892751.0608557938</CO2>
+                <H2O units="g" is_input="False">1134178.4666493235</H2O>
+                <HC units="g" is_input="False">458.43915385987225</HC>
+                <NOx units="g" is_input="False">10452.412708005086</NOx>
+                <SOx units="g" is_input="False">733.5026461757957</SOx>
+              </turboshaft_1>
+            </turboshaft>
+          </he_power_train>
+        </sizing>
+      </operation>
+    </environmental_impact>
+  </data>
+  <xfoil>
+    <horizontal_tail>
+      <CL is_input="False">[-0.5486, -0.5404, -0.5499, -0.5338, -1.0204, -1.099, -1.1459, -1.1794, -1.2028, -1.2165, -1.223, -1.2298, -1.2208, -1.2072, -1.1894, -1.1759, -1.1492, -1.1148, -1.0832, -1.0434, -1.0032, -0.9656, -0.9231, -0.8855, -0.8455, -0.8054, -0.7645, -0.7229, -0.6805, -0.6277, -0.5532, -0.4802, -0.4066, -0.3305, -0.2652, -0.2092, -0.1553, -0.1036, -0.0518, -0.0, 0.0518, 0.1036, 0.1553, 0.2092, 0.2651, 0.3306, 0.4066, 0.4802, 0.5532, 0.6277, 0.6804, 0.7228, 0.7644, 0.8053, 0.8454, 0.8854, 0.9231, 0.9656, 1.0033, 1.0436, 1.0834, 1.1151, 1.1495, 1.1764, 1.1901, 1.208, 1.2218, 1.2309, 1.2236, 1.2179, 1.2043, 1.1811, 1.1476, 1.1004, 1.0207, 0.7824, 0.7838, 0.7994, 0.818, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</CL>
+      <alpha units="deg" is_input="False">[-20.0, -19.5, -19.0, -18.5, -17.5, -17.0, -16.5, -16.0, -15.5, -15.0, -14.5, -14.0, -13.5, -13.0, -12.5, -12.0, -11.5, -11.0, -10.5, -10.0, -9.5, -9.0, -8.5, -8.0, -7.5, -7.0, -6.5, -6.0, -5.5, -5.0, -4.5, -4.0, -3.5, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0, 12.5, 13.0, 13.5, 14.0, 14.5, 15.0, 15.5, 16.0, 16.5, 17.0, 17.5, 18.0, 18.5, 19.0, 19.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</alpha>
+    </horizontal_tail>
+    <vertical_tail>
+      <CL is_input="False">[-0.0563, -0.0, 0.0563, 0.11307171182347858, 0.2254434236469572, 0.2811434236469572, 0.3364792795586965, 0.39198684729391436, 0.44718684729391434, 0.5021944150291323, 0.5564736945878287, 0.6107378386760894, 0.6641888300582645, 0.7177661268526109, 0.7747055849708677, 0.8345772967943463, 0.8998601785595605, 0.9646884667360818, 1.0280601785595604, 1.131168109616961, 1.2233322537052216, 1.3193398214404395, 1.410862524646093, 1.4968700923813112, 1.5618214470856686, 1.6109800062030617, 1.6441971244378475, 1.6546198276435011, 1.6212688362613261, 1.5149596490839405, 1.0869473891756574, 1.1756812623230468, 1.2718246859700038, 1.3663322537052216, 1.4553983805578325, 1.5336266687343538, 1.588164870732626, 1.6298744212321936, 1.6532481158200225, 1.6454481158200227, 1.5789122599082832, -1.609915862114801, -1.5873290148208867, -1.561121447085669, -1.5332266687343539, -1.496534236469572, -1.4551983805578323, -1.410662524646093, -1.3661322537052216, -1.3192039655287002, -1.2717246859700038, -1.2232681096169609, -1.175717118234786, -1.0871473891756576, -1.0279601785595605, -0.9645526108243426, -0.8996960344712998, -0.7746055849708677, -0.6641888300582645, -0.5564736945878287, -0.44718684729391434, -1.5114520813487229, -1.6188405480848047, -1.5758839717317619, -1.643019827643501, -0.33654342364695716, -1.652627395378719, -1.651483971731762, -1.6427329803495867, -1.628638565320455, -1.131268109616961, -0.22547927955869648, -0.11300756773521789, -0.8344772967943463, -0.7177302709408715, -0.6107378386760894, -0.5021944150291323, -0.39198684729391436, -0.2811434236469572, -0.1691717118234786, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</CL>
+      <alpha units="deg" is_input="False">[-0.5, 0.0, 0.5, 1.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5, 17.5, 18.5, 19.5, -16.0, -15.5, -15.0, -14.5, -14.0, -13.5, -13.0, -12.5, -12.0, -11.5, -11.0, -10.5, -9.5, -9.0, -8.5, -8.0, -7.0, -6.0, -5.0, -4.0, -20.0, -19.0, -19.5, -18.5, -3.0, -18.0, -17.5, -17.0, -16.5, -10.0, -2.0, -1.0, -7.5, -6.5, -5.5, -4.5, -3.5, -2.5, -1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</alpha>
+    </vertical_tail>
+    <wing>
+      <CL is_input="False">[-1.1177, -1.1495, -1.1686, -1.1713, -1.1636, -1.1494, -1.1243, -1.0922, -1.0529, -1.0127, -0.9723, -0.9313, -0.8886, -0.8466, -0.8054, -0.7649, -0.7256, -0.6856, -0.6464, -0.5803, -0.5046, -0.4289, -0.3567, -0.2843, -0.2245, -0.171, -0.119, -0.0719, -0.0276, 0.0208, 0.0693, 0.1187, 0.1688, 0.2228, 0.2849, 0.3614, 0.4348, 0.512, 0.5891, 0.6446, 0.6906, 0.7364, 0.7822, 0.828, 0.8736, 0.9184, 0.9632, 1.0083, 1.0537, 1.0985, 1.1433, 1.1884, 1.232, 1.2706, 1.3053, 1.3352, 1.356, 1.3697, 1.3737, 1.3707, 1.3807, 1.3806, 1.3685, 1.3444, 1.3116, 1.2779, 1.2492, 1.2261, 1.2081, 1.1964, 1.1865, 1.1772, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</CL>
+      <alpha units="deg" is_input="False">[-15.5, -15.0, -14.5, -14.0, -13.5, -13.0, -12.5, -12.0, -11.5, -11.0, -10.5, -10.0, -9.5, -9.0, -8.5, -8.0, -7.5, -7.0, -6.5, -6.0, -5.5, -5.0, -4.5, -4.0, -3.5, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0, 12.5, 13.0, 13.5, 14.0, 14.5, 15.0, 15.5, 16.0, 16.5, 17.0, 17.5, 18.0, 18.5, 19.0, 19.5, 20.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</alpha>
+    </wing>
+  </xfoil>
+  <settings>
+    <geometry>
+      <fuel_tanks>
+        <depth is_input="True">1.0<!--ratio of the tank depth as a percentage of the wing depth--></depth>
+      </fuel_tanks>
+    </geometry>
+    <handling_qualities>
+      <rudder>
+        <safety_margin is_input="True">0.3<!--Ratio of the total rudder deflection not used in the computation of the VT area to leave a safety margin--></safety_margin>
+      </rudder>
+    </handling_qualities>
+    <propulsion>
+      <turboprop>
+        <electric_power_offtake units="W" is_input="True">10000.0<!--power used for electrical generation obtained from the HP shaft--></electric_power_offtake>
+        <bleed>
+          <inter_compressor units="kg/s" is_input="True">0.04<!--total compressor airflow extracted after the first  compression stage (in station 25)--></inter_compressor>
+          <turbine_cooling is_input="True">0.05<!--percentage of the total aspirated airflow used for turbine cooling (fixed)--></turbine_cooling>
+        </bleed>
+        <design_point>
+          <first_stage_pressure_ratio is_input="True">0.25<!--ratio of the first stage pressure ratio to the OPR at the design point--></first_stage_pressure_ratio>
+          <mach_exhaust is_input="True">0.4<!--mach number at the exhaust in the design point--></mach_exhaust>
+        </design_point>
+        <efficiency>
+          <combustion units="J/kg" is_input="True">41097000.0<!--fuel energy content--></combustion>
+          <first_compressor_stage is_input="True">0.85<!--first compressor stage polytropic efficiency--></first_compressor_stage>
+          <gearbox is_input="True">0.98<!--power shaft mechanical efficiency--></gearbox>
+          <high_pressure_axe is_input="True">0.98<!--high pressure axe mechanical efficiency--></high_pressure_axe>
+          <high_pressure_turbine is_input="True">0.86<!--high pressure turbine  polytropic efficiency--></high_pressure_turbine>
+          <power_turbine is_input="True">0.86<!--power turbine  polytropic efficiency--></power_turbine>
+          <second_compressor_stage is_input="True">0.86<!--second compressor stage polytropic efficiency--></second_compressor_stage>
+        </efficiency>
+        <pressure_loss>
+          <combustion_chamber is_input="True">0.95<!--combustion chamber pressure loss--></combustion_chamber>
+          <inlet is_input="True">0.8<!--inlet total pressure loss--></inlet>
+        </pressure_loss>
+      </turboprop>
+      <he_power_train>
+        <propeller>
+          <propeller_1>
+            <effective_advance_ratio is_input="True">0.95<!--Decrease in power coefficient due to installation effects of the propeller--></effective_advance_ratio>
+            <installation_effect is_input="True">0.98<!--Increase in the power coefficient due to installation effects on the propeller--></installation_effect>
+          </propeller_1>
+        </propeller>
+        <turboshaft>
+          <turboshaft_1>
+            <cg_in_nacelle is_input="True">0.5<!--Location of the engine CG in the nacelle, in percent of the nacelle length--></cg_in_nacelle>
+            <k_sfc is_input="True">1.05<!--K-factor to adjust the sfc/fuel consumption of the turboshaft--></k_sfc>
+          </turboshaft_1>
+        </turboshaft>
+      </he_power_train>
+    </propulsion>
+    <weight>
+      <aircraft>
+        <MLW_MZFW_ratio is_input="True">1.063</MLW_MZFW_ratio>
+        <CG>
+          <range is_input="True">0.26<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG potentially fwd of the computed one, as currently, FAST-OAD uses the aft position of CG as a reference)--></range>
+          <aft>
+            <MAC_position>
+              <margin is_input="True">0.0<!--Added margin for getting most aft CG position, as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </aft>
+          <fwd>
+            <MAC_position>
+              <margin is_input="True">0.0<!--Added margin for getting most fwd CG position, as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </fwd>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg" is_input="True">77.0<!--Design value of mass per passenger--></design_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <paint>
+          <surface_density units="kg/m**2" is_input="True">0.28</surface_density>
+        </paint>
+        <landing_gear>
+          <front>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--></front_fuselage_ratio>
+            <weight_ratio is_input="True">0.24<!--part of aircraft weight that is supported by front landing gear, should not be lower than 0.08. Roskam--></weight_ratio>
+          </front>
+        </landing_gear>
+      </airframe>
+      <propulsion>
+        <tank>
+          <CG>
+            <from_wingMAC25 is_input="True">0.0<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
+          </CG>
+        </tank>
+      </propulsion>
+    </weight>
+    <aerodynamics>
+      <aircraft>
+        <undesirable_drag>
+          <k_factor is_input="True">1.25<!--Correction coefficient to take into account the other undesirable drag, default is 1.25 as suggested in Gudmundsson--></k_factor>
+        </undesirable_drag>
+      </aircraft>
+      <reference_flight_conditions>
+        <cruise>
+          <AOA units="rad" is_input="True">0.017453292519943295</AOA>
+        </cruise>
+        <low_speed>
+          <AOA units="rad" is_input="True">0.08726646259971647</AOA>
+        </low_speed>
+      </reference_flight_conditions>
+    </aerodynamics>
+    <mission>
+      <sizing>
+        <main_route>
+          <reserve>
+            <speed>
+              <k_factor is_input="True">1.5<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+            </speed>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+  </settings>
+  <constraints>
+    <propulsion>
+      <he_power_train>
+        <turboshaft>
+          <turboshaft_1>
+            <power_rating units="kW" is_input="False">-4.510664054311405<!--Respected if <0--></power_rating>
+          </turboshaft_1>
+        </turboshaft>
+      </he_power_train>
+    </propulsion>
+  </constraints>
+  <convergence>
+    <propulsion>
+      <he_power_train>
+        <propeller>
+          <propeller_1>
+            <min_power units="W" is_input="True">5000.0<!--Convergence parameter used to aid convergence since, if power is too low in the network, the code will have trouble converging--></min_power>
+          </propeller_1>
+        </propeller>
+      </he_power_train>
+    </propulsion>
+  </convergence>
+</FASTOAD_model>

--- a/src/fastga_he/models/loops/units_tests/data/turboshaft_propulsion.yml
+++ b/src/fastga_he/models/loops/units_tests/data/turboshaft_propulsion.yml
@@ -1,0 +1,39 @@
+title: Powertrain file for the sizing of the Cirrus SR22
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  turboshaft_1:
+    id: fastga_he.pt_component.turboshaft
+    position: in_the_front  # "on_the_wing", "in_the_front", "in_the_back"
+
+  fuel_system_1:
+    id: fastga_he.pt_component.fuel_system
+    options:
+      number_of_engines: 1
+      number_of_tanks: 2
+    position: in_the_front  # "in_the_wing", "in_the_front", "in_the_back"
+
+  fuel_tank_1:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+  fuel_tank_2:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+    symmetrical: fuel_tank_1
+
+component_connections:
+  - source: propeller_1
+    target: turboshaft_1
+
+  - source: turboshaft_1
+    target: [fuel_system_1, 1]
+
+  - source: [fuel_system_1, 1]
+    target: fuel_tank_1
+
+  - source: [fuel_system_1, 2]
+    target: fuel_tank_2
+
+watcher_file_path: ../results/fuel_propulsion_pt_watcher.csv

--- a/src/fastga_he/models/loops/units_tests/test_loops.py
+++ b/src/fastga_he/models/loops/units_tests/test_loops.py
@@ -117,7 +117,7 @@ def test_advanced_cl_with_proper_submodels_turboshaft():
         ),
         ivc_loop,
     )
-    assert_allclose(problem_loop["wing_area"], 23.03, atol=1e-2)
+    assert_allclose(problem_loop["wing_area"], 23.36, atol=1e-2)
 
 
 def test_advanced_cl_with_proper_submodels():

--- a/src/fastga_he/models/loops/units_tests/test_loops.py
+++ b/src/fastga_he/models/loops/units_tests/test_loops.py
@@ -86,6 +86,40 @@ def test_advanced_cl():
     )
 
 
+def test_advanced_cl_with_proper_submodels_turboshaft():
+    xml_file = "kodiak_100.xml"
+    propulsion_file = pth.join(DATA_FOLDER_PATH, "turboshaft_propulsion.yml")
+
+    oad.RegisterSubmodel.active_models["submodel.performances_he.energy_consumption"] = (
+        "fastga_he.submodel.performances.energy_consumption.from_pt_file"
+    )
+    oad.RegisterSubmodel.active_models["submodel.performances_he.dep_effect"] = (
+        "fastga_he.submodel.performances.dep_effect.from_pt_file"
+    )
+
+    inputs_list = list_inputs(
+        UpdateWingAreaLiftDEPEquilibrium(
+            propulsion_id="fastga.wrapper.propulsion.basicIC_engine",
+            power_train_file_path=propulsion_file,
+        )
+    )
+    # Research independent input value in .xml file
+    ivc_loop = get_indep_var_comp(
+        inputs_list,
+        __file__,
+        xml_file,
+    )
+
+    problem_loop = run_system(
+        UpdateWingAreaLiftDEPEquilibrium(
+            propulsion_id="fastga.wrapper.propulsion.basicIC_engine",
+            power_train_file_path=propulsion_file,
+        ),
+        ivc_loop,
+    )
+    assert_allclose(problem_loop["wing_area"], 23.03, atol=1e-2)
+
+
 def test_advanced_cl_with_proper_submodels():
     xml_file = "pipistrel_like.xml"
     propulsion_file = pth.join(DATA_FOLDER_PATH, "simple_assembly.yml")

--- a/src/fastga_he/models/loops/wing_area_component/wing_area_cl_dep_equilibrium.py
+++ b/src/fastga_he/models/loops/wing_area_component/wing_area_cl_dep_equilibrium.py
@@ -317,6 +317,13 @@ def compute_wing_area(inputs, propulsion_id, pt_file_path, control_parameter_lis
         )
         model.add_subsystem("thrust_rate_id", _IDThrustRate(), promotes=["*"])
 
+        configurator = FASTGAHEPowerTrainConfigurator()
+        configurator.load(pt_file_path)
+        slip_ins, perf_outs = configurator.get_performances_to_slipstream_element_lists()
+
+        for perf_out, slip_in in zip(perf_outs, slip_ins):
+            model.connect("power_train_performances." + perf_out, slip_in)
+
         # SLSQP uses gradient ?
         problem.driver = om.ScipyOptimizeDriver()
         problem.driver.options["disp"] = False

--- a/src/fastga_he/powertrain_builder/powertrain.py
+++ b/src/fastga_he/powertrain_builder/powertrain.py
@@ -2141,10 +2141,7 @@ class FASTGAHEPowerTrainConfigurator:
             ):
                 simplified_serializer.data[KEY_PT_COMPONENTS].pop(component_name)
             else:
-                if not (component_id == "fastga_he.pt_component.turboshaft"):
-                    retained_components.append(component_name)
-                else:
-                    simplified_serializer.data[KEY_PT_COMPONENTS].pop(component_name)
+                retained_components.append(component_name)
 
         # Then we pop all the connections that don't involve the components we have
         self._get_connections()


### PR DESCRIPTION
In the model to compute the wing area based on the advanced aerodynamic model, there was an issue when a turboshaft was present in the powertrain. This issue came from the fact that in this model, we compute the equilibrium of the aircraft using the same computation core as in the mission. However in the mission there was a manual connection of some variable that are computed in the performance and used in the slipstream effect computation that was absent from this model. This PR adds a test to reproduce the bug as well as a fix.