### PR TITLE
Warning message for negative cruise distance

### DIFF
--- a/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
+++ b/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
@@ -217,7 +217,8 @@ class InitializeTimeAndDistance(om.ExplicitComponent):
         cruise_range = mission_range - position_climb[-1] - position_descent[-1]
         if cruise_range < 0.0:
             _LOGGER.warning(
-                "Negative cruise range, consider adjusting range in the TLARs or climb and descent parameters"
+                "Negative cruise range, consider adjusting range in the TLARs or climb and "
+                "descent parameters"
             )
         cruise_distance_step = cruise_range / (number_of_points_cruise + 1)
         position_cruise = np.linspace(

--- a/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
+++ b/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
@@ -216,7 +216,7 @@ class InitializeTimeAndDistance(om.ExplicitComponent):
         # Cruise position computation
         cruise_range = mission_range - position_climb[-1] - position_descent[-1]
         if cruise_range < 0.0:
-            _LOGGER.warning("Negative cruise range, please check the inputs")
+            _LOGGER.warning("Negative cruise range, consider adjusting range in the TLARs or climb and descent parameters")
         cruise_distance_step = cruise_range / (number_of_points_cruise + 1)
         position_cruise = np.linspace(
             position_climb[-1] + cruise_distance_step,

--- a/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
+++ b/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
@@ -215,7 +215,7 @@ class InitializeTimeAndDistance(om.ExplicitComponent):
 
         # Cruise position computation
         cruise_range = mission_range - position_climb[-1] - position_descent[-1]
-        if cruise_range < 0:
+        if cruise_range < 0.0:
             _LOGGER.warning("Negative cruise range, please check the inputs")
         cruise_distance_step = cruise_range / (number_of_points_cruise + 1)
         position_cruise = np.linspace(

--- a/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
+++ b/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
@@ -216,7 +216,9 @@ class InitializeTimeAndDistance(om.ExplicitComponent):
         # Cruise position computation
         cruise_range = mission_range - position_climb[-1] - position_descent[-1]
         if cruise_range < 0.0:
-            _LOGGER.warning("Negative cruise range, consider adjusting range in the TLARs or climb and descent parameters")
+            _LOGGER.warning(
+                "Negative cruise range, consider adjusting range in the TLARs or climb and descent parameters"
+            )
         cruise_distance_step = cruise_range / (number_of_points_cruise + 1)
         position_cruise = np.linspace(
             position_climb[-1] + cruise_distance_step,

--- a/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
+++ b/src/fastga_he/models/performances/mission_vector/initialization/initialize_time_and_distance.py
@@ -215,6 +215,8 @@ class InitializeTimeAndDistance(om.ExplicitComponent):
 
         # Cruise position computation
         cruise_range = mission_range - position_climb[-1] - position_descent[-1]
+        if cruise_range < 0:
+            _LOGGER.warning("Negative cruise range, please check the inputs")
         cruise_distance_step = cruise_range / (number_of_points_cruise + 1)
         position_cruise = np.linspace(
             position_climb[-1] + cruise_distance_step,


### PR DESCRIPTION
The cruise distance is calculated by subtracting the climb and descent distances from the total mission range. As a result, there is a possibility that the computed cruise distance becomes negative if the sum of the climb and descent distances exceeds the total mission range.