### PR TITLE
Battery SoC Refinement

### DIFF
--- a/integration_tests/pipistrel/data/pipistrel_assembly_lower_soc_start.yml
+++ b/integration_tests/pipistrel/data/pipistrel_assembly_lower_soc_start.yml
@@ -1,0 +1,73 @@
+title: Sample power train file for testing purposes
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+    position: from_rear_to_front  # "inside_the_wing", "from_rear_to_front", "from_rear_to_wing", "from_front_to_wing", "from_rear_to_nose", "from_front_to_nose", "from_wing_to_nose"
+
+  dc_splitter_1:
+    id: fastga_he.pt_component.dc_splitter
+    position: in_the_back  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: in_the_front
+  battery_pack_1:
+    id: fastga_he.pt_component.battery_pack
+    position: in_the_front  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+  dc_sspc_2:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: in_the_back
+  battery_pack_2:
+    id: fastga_he.pt_component.battery_pack
+    position: in_the_back  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+component_connections:
+  - source: propeller_1
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: [dc_bus_1, 1]
+
+  - source: [dc_bus_1, 1]
+    target: harness_1
+
+  - source: harness_1
+    target: dc_splitter_1
+
+  - source: [dc_splitter_1, 1]
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: battery_pack_1
+
+  - source: [dc_splitter_1, 2 ]
+    target: dc_sspc_2
+
+  - source: dc_sspc_2
+    target: battery_pack_2
+
+watcher_file_path: ../results/pipistrel_power_train_data_lower_soc_start.csv

--- a/integration_tests/pipistrel/data/pipistrel_lower_soc_start_configuration.yml
+++ b/integration_tests/pipistrel/data/pipistrel_lower_soc_start_configuration.yml
@@ -1,0 +1,101 @@
+title: Sample OAD Process
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/pipistrel_lower_soc_start_in.xml
+output_file: ../results/pipistrel_lower_soc_start_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
+
+model:
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=20, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  linear_solver: om.LinearBlockGS()
+  geometry:
+    id: fastga.geometry.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    cabin_sizing: 0.0 # Manually input the front, rear and cabin length
+  aerodynamics_lowspeed:
+    id: fastga.aerodynamics.lowspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path : ../workdir
+    compute_slipstream : false
+  aerodynamics_highspeed:
+    id: fastga.aerodynamics.highspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path: ../workdir
+    compute_mach_interpolation: false
+    compute_slipstream: false
+  performances:
+    id: fastga_he.performances.mission_vector
+    number_of_points_climb: 30
+    number_of_points_cruise: 30
+    number_of_points_descent: 20
+    number_of_points_reserve: 10
+    power_train_file_path: ./pipistrel_assembly_lower_soc_start.yml
+    out_file: ../results/mission_data_lower_soc_start.csv
+    use_linesearch: False
+    pre_condition_pt: True
+    use_apply_nonlinear: True
+  power_train_sizing:
+    id: fastga_he.power_train.sizing
+    power_train_file_path: ./pipistrel_assembly_lower_soc_start.yml
+  weight:
+    id: fastga.weight.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  mtow:
+    id: fastga.loop.mtow
+  hq:
+    tail_sizing:
+      id: fastga.handling_qualities.tail_sizing
+      propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    static_margin:
+      id: fastga.handling_qualities.static_margin
+  wing_position:
+    id: fastga.loop.wing_position
+  wing_area:
+    id: fastga.loop.wing_area
+#    power_train_file_path: ./pipistrel_assembly.yml
+
+submodels:
+  submodel.performances_he.energy_consumption: fastga_he.submodel.performances.energy_consumption.from_pt_file
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.performances.dc_line.temperature_profile: fastga_he.submodel.propulsion.performances.dc_line.temperature_profile.with_dynamics
+  service.weight.mass.propulsion: fastga_he.submodel.weight.mass.propulsion.power_train
+  submodel.weight.cg.propulsion: fastga_he.submodel.weight.cg.propulsion.power_train
+  submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+  submodel.performances.mission_vector.climb_speed: null 
+  submodel.performances.mission_vector.descent_speed: null
+  service.weight.mass.system.power_system: null
+  service.weight.mass.system.avionics_system: null
+  service.weight.mass.system.life_support_system: null
+  service.weight.mass.system.recording_system: null
+  service.weight.mass.systems: fastga_he.submodel.weight.mass.systems.weight_nan
+  service.weight.mass.payload: null
+  service.geometry.nacelle.dimension: null
+  submodel.aerodynamics.nacelle.cd0: fastga_he.submodel.aerodynamics.powertrain.cd0.from_pt_file
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null
+  submodel.performances_he.dep_effect: fastga_he.submodel.performances.dep_effect.from_pt_file
+  service.weight.mass.airframe.wing: fastga_he.submodel.weight.mass.airframe.wing.analytical_he # No real use for this submodel as there are no electric components in the wing
+  submodel.handling_qualities.vertical_tail.area: null
+
+optimization: # This section is needed only if optimization process is run
+  design_variables:
+    - name: data:propulsion:he_power_train:propeller:propeller_1:solidity
+      lower: 0.1
+      upper: 0.4
+    - name: data:propulsion:he_power_train:propeller:propeller_1:activity_factor
+      lower: 50
+      upper: 250
+    - name: data:propulsion:he_power_train:propeller:propeller_1:blade_twist
+      lower: 10
+      upper: 35
+  objective:
+    - name: data:mission:sizing:energy
+      scaler: 1.e-4

--- a/integration_tests/pipistrel/data/pipistrel_source_lower_soc_start.xml
+++ b/integration_tests/pipistrel/data/pipistrel_source_lower_soc_start.xml
@@ -1,0 +1,689 @@
+<FASTOAD_model>
+  <data>
+    <TLAR>
+      <NPAX_design is_input="True">0.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
+      <luggage_mass_design units="kg" is_input="True">10.0<!--luggage design mass--></luggage_mass_design>
+      <range units="km" is_input="True">53.0<!--top-level requirement: design range--></range>
+      <v_approach units="knot" is_input="True">58.5<!--approach speed--></v_approach>
+      <v_cruise units="knot" is_input="True">93.0<!--cruise speed--></v_cruise>
+      <v_max_sl units="knot" is_input="True">110.0<!--maximum speed at sea level--></v_max_sl>
+    </TLAR>
+    <geometry>
+      <flap_type is_input="True">1.0<!--flap type (0.0 - plain flap, 2.0 - single slotted flap, 3.0 - split flap)--></flap_type>
+      <has_T_tail is_input="True">1.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <wing_configuration is_input="True">3.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></wing_configuration>
+      <cabin>
+        <aisle_width units="m" is_input="True">0.0<!--width of aisles--></aisle_width>
+        <luggage>
+          <mass_max units="kg" is_input="True">10.0<!--maximum luggage weight in the luggage compartment--></mass_max>
+        </luggage>
+        <seats>
+          <passenger>
+            <NPAX_max is_input="True">0.0<!--maximum number of passengers in the aircraft--></NPAX_max>
+            <count_by_row is_input="True">2.0<!--number of passenger seats per row--></count_by_row>
+            <length units="m" is_input="True">0.8<!--passenger seats length--></length>
+            <width units="m" is_input="True">0.565<!--width of passenger seats--></width>
+          </passenger>
+          <pilot>
+            <length units="m" is_input="True">0.7<!--pilot seats length--></length>
+            <width units="m" is_input="True">0.565<!--width of pilot seats--></width>
+          </pilot>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio is_input="True">0.2<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio is_input="True">0.88<!--ratio (width of flaps)/(total span)--></span_ratio>
+      </flap>
+      <horizontal_tail>
+        <aspect_ratio is_input="True">4.65<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <elevator_chord_ratio is_input="True">0.4<!--elevator chord ratio--></elevator_chord_ratio>
+        <sweep_25 units="deg" is_input="True">4.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio is_input="True">0.6<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.125<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m" is_input="True">4.1<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </horizontal_tail>
+      <landing_gear>
+        <type is_input="True">0.0<!--0=non-retractable / 1=retractable--></type>
+      </landing_gear>
+      <propeller>
+        <depth units="m" is_input="True">0.15<!--depth of the propeller--></depth>
+        <diameter units="m" is_input="True">1.2<!--propeller diameter--></diameter>
+      </propeller>
+      <vertical_tail>
+        <area units="m**2">0.86</area>
+        <aspect_ratio is_input="True">1.43<!--aspect ratio of vertical tail--></aspect_ratio>
+        <sweep_25 units="deg" is_input="True">30.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio is_input="True">0.62<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.125<!--thickness ratio of vertical tail--></thickness_ratio>
+        <max_thickness>
+          <x_ratio is_input="True">0.3<!--position of the point of maximum thickness as a ratio of vertical tail chord--></x_ratio>
+        </max_thickness>
+        <rudder>
+          <chord_ratio is_input="True">0.4<!--flap rudder as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg" is_input="True">30.0<!--rudder maximum deflection--></max_deflection>
+        </rudder>
+      </vertical_tail>
+      <wing>
+        <aileron>
+          <chord_ratio is_input="True">0.2<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+          <span_ratio is_input="True">0.2<!--ratio (width of flaps)/(total span)--></span_ratio>
+          <max_deflection units="deg">15.0</max_deflection>
+        </aileron>
+        <aspect_ratio is_input="True">12.04<!--wing aspect ratio--></aspect_ratio>
+        <sweep_25 units="deg" is_input="True">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <dihedral units="deg" is_input="True">0.0<!--sweep angle at 25% chord of wing--></dihedral>
+        <twist units="deg" is_input="True">0.0<!--sweep angle at 25% chord of wing--></twist>
+        <taper_ratio is_input="True">1.0<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio is_input="True">0.15<!--mean thickness ratio of wing--></thickness_ratio>
+        <kink>
+          <span_ratio is_input="True">0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+        </kink>
+      </wing>
+      <propulsion>
+        <engine>
+          <count is_input="True">1.0<!--number of engines--></count>
+          <layout is_input="True">3.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
+          <y_ratio is_input="True">0.34<!--engine position with respect to total span--></y_ratio>
+        </engine>
+        <nacelle>
+          <height units="m" is_input="True">0.6230628899061188<!--height of the nacelle--></height>
+          <length units="m" is_input="True">0.35<!--length of the nacelle--></length>
+          <master_cross_section units="m**2" is_input="True">0.5789057194060345</master_cross_section>
+          <wet_area units="m**2" is_input="True">1.09<!--nacelle wet area--></wet_area>
+          <width units="m" is_input="True">0.9291288709126333<!--width of the nacelle--></width>
+        </nacelle>
+        <tank>
+          <LE_chord_percentage>0.2</LE_chord_percentage>
+          <TE_chord_percentage>0.8</TE_chord_percentage>
+          <y_ratio_tank_beginning>0.4</y_ratio_tank_beginning>
+          <y_ratio_tank_end>0.6</y_ratio_tank_end>
+        </tank>
+      </propulsion>
+      <fuselage>
+        <front_length units="m">1.0</front_length>
+        <rear_length units="m">4.0</rear_length>
+        <PAX_length units="m">1.1</PAX_length>
+        <luggage_length units="m">0.4</luggage_length>
+        <length units="m">6.5</length>
+        <maximum_height units="m" is_input="False">1.3378<!--maximum height of the fuselage--></maximum_height>
+        <maximum_width units="m" is_input="False">1.1978<!--maximum width of the fuselage--></maximum_width>
+      </fuselage>
+    </geometry>
+    <propulsion>
+      <fuel_type is_input="True">1.0<!--engine fuel type (1.0 - gasoline, 2.0 - gasoil)--></fuel_type>
+      <max_rpm units="1/min">5800.0</max_rpm>
+      <IC_engine>
+        <max_power units="kW" is_input="True">60.0<!--maximum power of the engine--></max_power>
+        <strokes_nb is_input="True">4.0<!--number of strokes on the engine--></strokes_nb>
+      </IC_engine>
+      <he_power_train>
+        <thrust_distribution is_input="True">1.0</thrust_distribution>
+        <DC_DC_converter>
+          <dc_dc_converter_1>
+            <current_ripple is_input="True">0.4<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <power_density units="W/kg" is_input="True">4000.0<!--Power density of the converter--></power_density>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the DC/DC converter for the points--></switching_frequency_mission>
+            <voltage_out_target_mission units="V" is_input="True">400.0<!--Target output voltage of the DC/DC converter for the points--></voltage_out_target_mission>
+            <voltage_ripple is_input="True">0.02<!--Amplitude of the voltage ripple as a percent of the voltage caliber--></voltage_ripple>
+            <capacitor>
+              <aspect_ratio is_input="True">2.0</aspect_ratio>
+            </capacitor>
+            <heat_sink>
+              <temperature_rating units="degK">373.15</temperature_rating>
+              <coolant>
+                  <temperature_in_rating units="degK">323.15</temperature_in_rating>
+                  <temperature_out_rating units="degK">353.15</temperature_out_rating>
+              </coolant>
+            </heat_sink>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="uH">75.0</inductance>
+              <resistance units="ohm" is_input="True">0.0014</resistance>
+            </inductor>
+            <CG>
+              <y_ratio>0.34</y_ratio>
+            </CG>
+          </dc_dc_converter_1>
+          <dc_dc_converter_2>
+            <current_ripple is_input="True">0.4<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <power_density units="W/kg" is_input="True">4000.0<!--Power density of the converter--></power_density>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the DC/DC converter for the points--></switching_frequency_mission>
+            <voltage_out_target_mission units="V" is_input="True">400.0<!--Target output voltage of the DC/DC converter for the points--></voltage_out_target_mission>
+            <voltage_ripple is_input="True">0.02<!--Amplitude of the voltage ripple as a percent of the voltage caliber--></voltage_ripple>
+            <capacitor>
+              <aspect_ratio is_input="True">2.0</aspect_ratio>
+            </capacitor>
+            <heat_sink>
+              <temperature_rating units="degK">373.15</temperature_rating>
+              <coolant>
+                  <temperature_in_rating units="degK">323.15</temperature_in_rating>
+                  <temperature_out_rating units="degK">353.15</temperature_out_rating>
+              </coolant>
+            </heat_sink>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <inductor>
+              <inductance units="uH">75.0</inductance>
+              <air_gap units="mm">2.7</air_gap>
+              <resistance units="ohm" is_input="True">0.0014</resistance>
+            </inductor>
+            <CG>
+              <y_ratio>0.34</y_ratio>
+            </CG>
+          </dc_dc_converter_2>
+        </DC_DC_converter>
+        <DC_SSPC>
+          <dc_sspc_1>
+            <low_speed>
+                <CD0>0.0</CD0>
+            </low_speed>
+            <cruise>
+                <CD0>0.0</CD0>
+            </cruise>
+            <CG>
+                <x units="m">2.69</x>
+                <y_ratio>0.34</y_ratio>
+            </CG>
+            <mass units="kg">10.0</mass>
+            <current_caliber units="A">800.0</current_caliber>
+            <voltage_caliber units="V">850.0</voltage_caliber>
+            <current_max units="A" is_input="False">226.9965558424665<!--Maximum current flowing through the SSPC--></current_max>
+            <voltage_max units="V" is_input="False">846.7684101430876<!--Maximum voltage at the terminals SSPC--></voltage_max>
+            <scaling>
+                <resistance>1.125</resistance>
+            </scaling>
+            <igbt>
+                <resistance units="ohm">0.00169875</resistance>
+            </igbt>
+            <diode>
+                <resistance units="ohm">0.00210375</resistance>
+            </diode>
+          </dc_sspc_1>
+          <dc_sspc_2>
+            <low_speed>
+                <CD0>0.0</CD0>
+            </low_speed>
+            <cruise>
+                <CD0>0.0</CD0>
+            </cruise>
+            <CG>
+                <x units="m">2.69</x>
+                <y_ratio>0.34</y_ratio>
+            </CG>
+            <mass units="kg">10.0</mass>
+            <current_caliber units="A">800.0</current_caliber>
+            <voltage_caliber units="V">850.0</voltage_caliber>
+            <current_max units="A" is_input="False">226.9965558424665<!--Maximum current flowing through the SSPC--></current_max>
+            <voltage_max units="V" is_input="False">846.7684101430876<!--Maximum voltage at the terminals SSPC--></voltage_max>
+            <scaling>
+                <resistance>1.125</resistance>
+            </scaling>
+            <igbt>
+                <resistance units="ohm">0.00169875</resistance>
+            </igbt>
+            <diode>
+                <resistance units="ohm">0.00210375</resistance>
+            </diode>
+          </dc_sspc_2>
+        </DC_SSPC>
+        <DC_splitter>
+          <dc_splitter_1>
+            <power_split>50.0</power_split>
+            <CG>
+              <y_ratio>0.34</y_ratio>
+            </CG>
+          </dc_splitter_1>
+        </DC_splitter>
+        <DC_bus>
+          <dc_bus_1>
+            <front_length_ratio is_input="True">0.9<!--Location of the DC bus CG as a ratio of the aircraft front length--></front_length_ratio>
+            <cross_section>
+              <density units="kg/m**3" is_input="True">8960.0<!--Density of the conductor, copper is assumed--></density>
+              <length units="m" is_input="True">0.3<!--Length of the bus bar conductor--></length>
+              <w_t_ratio is_input="True">20.0</w_t_ratio>
+            </cross_section>
+          </dc_bus_1>
+          <dc_bus_2>
+            <cross_section>
+              <density units="kg/m**3" is_input="True">8960.0<!--Density of the conductor, copper is assumed--></density>
+              <length units="m" is_input="True">0.3<!--Length of the bus bar conductor--></length>
+              <w_t_ratio is_input="True">20.0</w_t_ratio>
+            </cross_section>
+          </dc_bus_2>
+        </DC_bus>
+        <DC_cable_harness>
+          <harness_1>
+            <length_span_ratio is_input="True">0.17<!--Length of the cable as a ratio of the SPAN (not half-span), used when cable is fully or partly inside the wing.--></length_span_ratio>
+            <material is_input="True">1.0<!--1.0 for copper, 0.0 for aluminium--></material>
+            <number_cables is_input="True">1.0</number_cables>
+            <cable>
+              <initial_temperature units="degK" is_input="True">288.15</initial_temperature>
+            </cable>
+            <conductor>
+              <k_factor_radius is_input="True">1.0<!--K-factor to increase the radius of the conducting core--></k_factor_radius>
+            </conductor>
+            <insulation>
+              <k_factor_radius is_input="True">1.0<!--K-factor to increase the radius of the insulation--></k_factor_radius>
+            </insulation>
+          </harness_1>
+        </DC_cable_harness>
+        <PMSM>
+          <motor_1>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">4500.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">650.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_1>
+        </PMSM>
+        <battery_pack>
+          <battery_pack_1>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">96.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_1>
+          <battery_pack_2>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">96.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_2>
+        </battery_pack>
+        <inverter>
+          <inverter_1>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_1>
+        </inverter>
+        <propeller>
+          <propeller_1>
+            <installation_angle units="deg" is_input="True">0.0</installation_angle>
+            <activity_factor is_input="True">125.0<!--Activity factor of the propeller--></activity_factor>
+            <blade_twist units="deg" is_input="True">20.0<!--Twist between the propeller blade root and tip--></blade_twist>
+            <depth_to_diameter_ratio is_input="True">0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="cm" is_input="True">164.0<!--Diameter of the propeller--></diameter>
+            <material is_input="True">1.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades is_input="True">3.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_mission units="1/min" is_input="True">[1780, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350,2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350,2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2350, 2300, 2300,2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300,2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300, 2300,2300, 2300, 2300, 2300, 2300, 2300, 1780, 1780, 1780, 1780, 1780,1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780,1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780, 1780,1780, 1780, 1780, 1780]<!--RPM of the propeller for the points--></rpm_mission>
+            <solidity is_input="True">0.135<!--Solidity of the propeller--></solidity>
+          </propeller_1>
+        </propeller>
+      </he_power_train>
+    </propulsion>
+    <handling_qualities>
+      <static_margin>
+        <target is_input="True">0.2<!--static margin we want to achieve--></target>
+      </static_margin>
+    </handling_qualities>
+    <weight>
+      <aircraft>
+        <max_payload units="kg" is_input="True">172.0<!--max payload weight--></max_payload>
+        <payload units="kg" is_input="True">172.0<!--design payload weight--></payload>
+      </aircraft>
+      <airframe>
+        <fuselage>
+          <k_factor is_input="True">0.85<!--proportional corrective factor for fuselage mass--></k_factor>
+        </fuselage>
+        <horizontal_tail>
+          <k_factor is_input="True">0.85<!--proportional corrective factor for horizontal tail mass--></k_factor>
+        </horizontal_tail>
+        <paint>
+          <mass units="lbm" is_input="True">0.0<!--Mass of the airframe_inp_data:weight:airframe:paint:mass--></mass>
+        </paint>
+        <vertical_tail>
+          <k_factor is_input="True">0.85<!--proportional corrective factor for vertical tail mass--></k_factor>
+        </vertical_tail>
+        <wing>
+          <k_factor is_input="True">0.85<!--proportional corrective factor for wing mass--></k_factor>
+        </wing>
+      </airframe>
+      <propulsion>
+        <engine>
+          <mass units="lbm" is_input="True">775.6880445165762<!--engine (B1): mass--></mass>
+        </engine>
+        <fuel_lines>
+          <mass units="lbm" is_input="True">125.79154244557245<!--fuel lines (B2): mass--></mass>
+        </fuel_lines>
+        <unusable_fuel>
+          <mass units="lbm" is_input="True">127.1301041026646<!--total unusable fuel mass--></mass>
+        </unusable_fuel>
+      </propulsion>
+      <systems>
+        <avionics>
+          <mass units="kg" is_input="True">10.0<!--total navigation systems mass--></mass>
+        </avionics>
+        <recording>
+          <mass units="kg" is_input="True">0.0</mass>
+        </recording>
+        <life_support>
+          <air_conditioning>
+            <mass units="kg" is_input="True">0.0<!--air conditioning mass--></mass>
+          </air_conditioning>
+          <de_icing>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de_icing:mass--></mass>
+          </de_icing>
+          <fixed_oxygen>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:fixed_oxygen:mass--></mass>
+          </fixed_oxygen>
+          <insulation>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:insulation:mass--></mass>
+          </insulation>
+          <internal_lighting>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:internal_lighting:mass--></mass>
+          </internal_lighting>
+          <seat_installation>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:seat_installation:mass--></mass>
+          </seat_installation>
+          <security_kits>
+            <mass units="kg" is_input="True">0.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:security_kits:mass--></mass>
+          </security_kits>
+        </life_support>
+        <power>
+          <electric_systems>
+            <mass units="kg" is_input="True">20.0<!--electric power system mass--></mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="kg" is_input="True">0.0<!--hydraulic power system mass--></mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+    <aerodynamics>
+      <cooling>
+        <cruise>
+          <CD0 is_input="True">0.0005525<!--profile drag due to cooling in cruise conditions--></CD0>
+        </cruise>
+        <low_speed>
+          <CD0 is_input="True">0.0005525<!--profile drag due to cooling in low speed conditions--></CD0>
+        </low_speed>
+      </cooling>
+      <propeller>
+        <cruise_level>
+          <altitude units="ft" is_input="True">8000.0<!--altitude at which the cruise level propeller efficiency map was computed--></altitude>
+          <efficiency is_input="True">[[0.10845978793506428, 0.1905792924289023, 0.22283519622744125, 0.22782743993001295, 0.22185689772726994, 0.21182400446080296, 0.20071564198808486, 0.18990256224052077, 0.17988358910153412, 0.17031219796074024, 0.16096555053505388, 0.15234971477975345, 0.1442190154337627, 0.13662395531518245, 0.12999440823095101, 0.12398337701764012, 0.11805240486412999, 0.11162023011718553, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491, 0.1094871079350491], [0.27448266832403434, 0.44863320742477686, 0.507031250496908, 0.5186419800190101, 0.5109239455695426, 0.4952950278049016, 0.47697227492688427, 0.4583346628302186, 0.44052719586208566, 0.42339265528824793, 0.4059229009792721, 0.3892106570215483, 0.37320840595984045, 0.35761730750090076, 0.34289475620255855, 0.32996139473023245, 0.31804167010388845, 0.30635878520695636, 0.29422248412608454, 0.27856101344871537, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427, 0.2740588871772427], [0.39259819216821173, 0.5858512688725387, 0.6463157998192718, 0.6608234681799189, 0.6564176726601565, 0.6437388690383259, 0.6272819681924144, 0.6095368618451817, 0.5925045128089136, 0.5761228139310233, 0.558313075537995, 0.5406009006026609, 0.5236878127541823, 0.5070962237713692, 0.4899846077738527, 0.47419881357470983, 0.4604075656647254, 0.44721414548738203, 0.434268260227683, 0.42099340736467883, 0.404975424997426, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764, 0.38604500202076764], [0.4564227051431568, 0.6523236444736029, 0.7106914937442873, 0.7288235460435083, 0.7292955690346392, 0.7214257625043183, 0.7093145079630059, 0.6952503113431062, 0.6807598242944074, 0.6675570313904946, 0.6524125053375942, 0.6363968346473835, 0.6208502920510462, 0.6055593276013705, 0.5903915120571352, 0.5740958400932449, 0.5597467920562222, 0.5468672557808258, 0.53421208367883, 0.5217355156023925, 0.5090596965556112, 0.49391861731298076, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522, 0.4706925174789522], [0.4791882537407273, 0.6740340219739058, 0.7370607329789776, 0.7594598631016342, 0.7652065866585606, 0.7621411160340578, 0.7546436685217245, 0.744657197584008, 0.7337423938757526, 0.7234038009794596, 0.7114466352802239, 0.6980741343217178, 0.6846537421382576, 0.6712403369355519, 0.6581192566002948, 0.6441723286776188, 0.630153869745789, 0.617767345779891, 0.606109022718372, 0.5946216000818297, 0.5831873092822016, 0.5715017523981044, 0.5579216971199367, 0.537703811251626, 0.5352182333972476, 0.5352182333972476, 0.5352182333972476, 0.5352182333972476, 0.5352182333972476, 0.5352182333972476], [0.47788522249662274, 0.6734740255783844, 0.7423920159207223, 0.7708530312595273, 0.7813780483059658, 0.7830276402862388, 0.7797895142408973, 0.7736534145156438, 0.766382614815679, 0.7586108390548422, 0.7492955878421311, 0.7386755031717499, 0.7275686105161068, 0.7162917583631455, 0.7050536157541983, 0.693380483448577, 0.6811151834284151, 0.6695214460707782, 0.65872540332444, 0.6483467614277886, 0.6380903117784728, 0.6278362056026158, 0.6173004150034093, 0.6051866026762122, 0.5885729049012112, 0.5812492372668139, 0.5812492372668139, 0.5812492372668139, 0.5812492372668139, 0.5812492372668139], [0.4697675205907046, 0.6642633645444713, 0.7379084070411505, 0.7713756933822162, 0.786823326190131, 0.7927895193052044, 0.7933744779960414, 0.7907084318524139, 0.7867151879674117, 0.7813567473486862, 0.774332058511535, 0.7661107850633151, 0.7571810752766688, 0.7478957037968941, 0.7384772208487176, 0.7287180084958786, 0.7183048899544322, 0.7080979818619003, 0.6983652547839133, 0.6889439393195471, 0.679682979560435, 0.6705492749144896, 0.6613926208117067, 0.651983571915788, 0.6413223360626632, 0.6273154622793741, 0.618961693437737, 0.618961693437737, 0.618961693437737, 0.618961693437737], [0.4346739697989151, 0.6456680328340672, 0.727294228369271, 0.7664495750805738, 0.7864195691831628, 0.7962564318574739, 0.8002083535001139, 0.8007301014985126, 0.7993154573703709, 0.7962163088551667, 0.7912565809286471, 0.78508131151072, 0.7781030754536995, 0.7706571862396775, 0.7628858768217502, 0.7547845345195872, 0.746095892853039, 0.737247641271942, 0.7286709363404259, 0.7202630328947105, 0.7120317818369815, 0.7038383289344148, 0.6956588220918484, 0.6874622408729439, 0.6790845871403025, 0.6697535590757375, 0.6580601586450291, 0.6485442354686446, 0.6485442354686446, 0.6485442354686446], [0.4197143395828548, 0.6308738227573676, 0.7157135407147314, 0.7589925292971775, 0.7828410894535459, 0.7960832608357843, 0.8030328270352525, 0.806299310421264, 0.8071040518601037, 0.8059260569867601, 0.8028248573312642, 0.7984324924413463, 0.7931759521461447, 0.7873489487184435, 0.7810799105889362, 0.7744277974554942, 0.7672659754488245, 0.7597231020613556, 0.7522385510402299, 0.7448653281706216, 0.7375385772654263, 0.7302257565471412, 0.7229653773783995, 0.7156790745144769, 0.708321023086667, 0.7008449243359339, 0.6926743656487436, 0.6829657051377548, 0.6720561088414093, 0.6720561088414093], [0.39063401557657657, 0.6100073370024869, 0.7029633041175517, 0.7503658373473623, 0.7775296207866136, 0.793797896010986, 0.8034221058321867, 0.80908699734833, 0.8117668607644362, 0.8122255700353568, 0.8108124971893591, 0.8080046765659191, 0.8042230442941409, 0.7997981511660802, 0.7948688861800585, 0.789491216126434, 0.7836596524547909, 0.777370389300691, 0.7708821393408832, 0.7644166171196375, 0.7579912806944538, 0.751526962123412, 0.7450187332206042, 0.7385217781914668, 0.7320105333339628, 0.7254182069560762, 0.7187011101605126, 0.711563012924546, 0.7034211503153479, 0.6886013681754592]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at cruise level--></efficiency>
+          <speed units="m/s" is_input="True">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at cruise level are computed--></speed>
+          <thrust units="N" is_input="True">[133.83908203273913, 319.93750135205653, 506.0359206713739, 692.1343399906913, 878.2327593100086, 1064.331178629326, 1250.4295979486433, 1436.5280172679606, 1622.626436587278, 1808.7248559065954, 1994.8232752259128, 2180.9216945452304, 2367.0201138645475, 2553.1185331838647, 2739.2169525031823, 2925.3153718225, 3111.413791141817, 3297.512210461134, 3483.6106297804517, 3669.7090490997693, 3855.8074684190865, 4041.9058877384036, 4228.004307057721, 4414.102726377039, 4600.201145696356, 4786.299565015674, 4972.397984334991, 5158.496403654309, 5344.594822973626, 5530.693242292943]<!--thrust produced by the propeller at cruise level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="True">[3346.3770766287334, 3699.9395479304203, 3974.3527497950317, 4209.073891629274, 4421.63404351857, 4626.504539375235, 4833.284955708378, 5048.374357861811, 5278.833938207545, 5530.693242292943]<!--maximum thrust output of the propeller at cruise level for varying velocities--></thrust_limit>
+        </cruise_level>
+        <sea_level>
+          <efficiency is_input="True">[[0.10861576395549595, 0.18982678369837674, 0.22232571209099866, 0.2279875408589875, 0.2224905341979893, 0.2127911290524655, 0.20189521325622473, 0.19120107759367683, 0.1812845835776059, 0.17180358256046582, 0.16248651076246856, 0.15387892256095878, 0.14576032082374268, 0.1381315462113196, 0.131419771938242, 0.12541624421223868, 0.11953427090180849, 0.11334616549362068, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689, 0.10985856549517689], [0.27474596735391066, 0.44722469162187134, 0.5062266822320689, 0.5187777939136637, 0.511878942215644, 0.49691021370351257, 0.47901049621194225, 0.4606786358235163, 0.44310999662268236, 0.42621449261431793, 0.40889781291201455, 0.392279447108923, 0.376359925488069, 0.3608574186916153, 0.3460309573013251, 0.33299526421268594, 0.32111602062045874, 0.30952116077745934, 0.2976702480177488, 0.28328091284280454, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131, 0.274879074066131], [0.39282425307774205, 0.5844403977820287, 0.6456084945812779, 0.660854259263562, 0.6572552647441976, 0.6452259955993277, 0.6292642511264365, 0.6118830434154883, 0.5951083527589245, 0.5790689825565984, 0.5615416068802974, 0.5439541986697958, 0.5271466090070905, 0.5107249834022523, 0.4937780310021779, 0.4778123876776081, 0.4640053738914316, 0.4508898581069629, 0.43803786757963625, 0.4250452720655391, 0.40982043256927225, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974, 0.38993428948758974], [0.45684056413672924, 0.6511048006943319, 0.7099555903370214, 0.728897437337207, 0.729951139845719, 0.722669206752231, 0.7110257999652879, 0.697317426572806, 0.6830976060020465, 0.6702258462334485, 0.6554028376438292, 0.6395604620909523, 0.6241557538672641, 0.6089979468693925, 0.594039297480944, 0.5778307665653332, 0.5634017693034336, 0.5505483154978281, 0.5380032049005905, 0.5256275718850042, 0.5131525768099104, 0.49876787737415934, 0.478152249877993, 0.4719165457283422, 0.4719165457283422, 0.4719165457283422, 0.4719165457283422, 0.4719165457283422, 0.4719165457283422, 0.4719165457283422], [0.47973530545832427, 0.6730315476489779, 0.7364852347247695, 0.759432268218157, 0.7656915626117462, 0.7631512625657675, 0.7560373786464266, 0.7464217207332887, 0.7358380294770787, 0.7257491666654721, 0.7140842189768428, 0.7009203059211937, 0.6876581930334951, 0.674387532561735, 0.6614116833372677, 0.6476880059258944, 0.6336876008231969, 0.6212984078528231, 0.6097162458146235, 0.5983183879480678, 0.5870137884465241, 0.5755111564291366, 0.5625346345722766, 0.5447866730963692, 0.5366249466364297, 0.5366249466364297, 0.5366249466364297, 0.5366249466364297, 0.5366249466364297, 0.5366249466364297], [0.47820333361790895, 0.6726840054631724, 0.7418695841344789, 0.7707715099382689, 0.7818186801775935, 0.7838495233779752, 0.7809573731490198, 0.7751689171383597, 0.7682071142488491, 0.7606768755095807, 0.7516082904188053, 0.7411847922798227, 0.7302502982319015, 0.7191299797020332, 0.7080405222610041, 0.6965261221018383, 0.6843740494176932, 0.6728582395254726, 0.6621131765298081, 0.651808170348312, 0.6416478894869156, 0.631497296101045, 0.6211346956870574, 0.6094362915595074, 0.5940652452999948, 0.5855326461194006, 0.5855326461194006, 0.5855326461194006, 0.5855326461194006, 0.5855326461194006], [0.4694931045042059, 0.6635460856789809, 0.7374925275126827, 0.7713547552037938, 0.7871755465807543, 0.7934875366500804, 0.7943857390481329, 0.7920469133671493, 0.7883628728065073, 0.7832339575612108, 0.7763765223641288, 0.7683443086379258, 0.7595826423981933, 0.7504504544415922, 0.7411742009015228, 0.7315502777905816, 0.7212595724145058, 0.7111602433010429, 0.7015025856449348, 0.6921734844022798, 0.6830038230116231, 0.6739521590982946, 0.6648895171767627, 0.6556219274373181, 0.6452605756318446, 0.6319372996573803, 0.6205958852174623, 0.6205958852174623, 0.6205958852174623, 0.6205958852174623], [0.43766433234088326, 0.6455651646912715, 0.727065578725185, 0.7664770573843499, 0.7867593117823916, 0.7969002551418934, 0.8011337960932291, 0.801976393496481, 0.8007995689371068, 0.7979051200359113, 0.7931044384471566, 0.7871031807308858, 0.780284499526611, 0.7729853885296435, 0.7653529672548778, 0.7573577608987059, 0.7487831885976286, 0.7400609812766556, 0.7315791208479387, 0.7232728690238694, 0.715132516675471, 0.7070204736575235, 0.6989282088866708, 0.6908080123810201, 0.6825308412879858, 0.6733687856914656, 0.662043810272736, 0.6503507920150341, 0.6503507920150341, 0.6503507920150341], [0.42000531178754674, 0.6304483617636587, 0.7158609319720957, 0.7591681203265189, 0.7832417907820967, 0.7967411250206564, 0.8039660359605387, 0.8075250104534676, 0.8085695675234238, 0.8075346171363608, 0.8045748579201557, 0.8003025709097618, 0.7951989777554349, 0.7895121142726619, 0.7833736919946631, 0.7768264316821364, 0.7697510285008111, 0.7623188002482142, 0.7549458285447884, 0.7476772542811684, 0.7404456303402324, 0.733211465459772, 0.7260435971866721, 0.7188402263891781, 0.7115535514297577, 0.7041366348545574, 0.696069531769388, 0.6864967380199367, 0.6740459667852505, 0.6740459667852505], [0.3946055426490841, 0.6102110722773023, 0.7029743701229202, 0.7507930306291433, 0.7780641597634084, 0.7945344192009683, 0.8044519156770126, 0.81032457467034, 0.8132401666928316, 0.813774032475982, 0.8124957542647285, 0.8097987944534369, 0.8061547787387005, 0.8018582756309856, 0.7970532812733194, 0.7917744688700021, 0.7860209965160677, 0.7798267850246555, 0.7734353695848538, 0.767072011291884, 0.7607480509796191, 0.754370400285992, 0.7479458167075219, 0.7415222175155555, 0.7350820198111645, 0.7285664795954853, 0.7218995657962757, 0.7147953092040504, 0.7066823627475524, 0.6931468410052888]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at sea level--></efficiency>
+          <speed units="m/s" is_input="True">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at sea level are computed--></speed>
+          <thrust units="N" is_input="True">[170.3880719879263, 403.1482426027868, 635.9084132176474, 868.6685838325079, 1101.4287544473684, 1334.188925062229, 1566.9490956770896, 1799.70926629195, 2032.4694369068106, 2265.229607521671, 2497.9897781365316, 2730.749948751392, 2963.5101193662526, 3196.270289981113, 3429.0304605959736, 3661.790631210834, 3894.5508018256946, 4127.310972440556, 4360.071143055416, 4592.831313670276, 4825.591484285137, 5058.351654899997, 5291.111825514858, 5523.871996129718, 5756.632166744579, 5989.39233735944, 6222.1525079743, 6454.91267858916, 6687.672849204021, 6920.433019818882]<!--thrust produced by the propeller at sea level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="True">[4232.24869825669, 4675.807054723695, 5017.410358731326, 5307.969328239218, 5571.20112011273, 5821.982703144951, 6074.726893728504, 6337.371791985532, 6616.053232440212, 6920.433019818882]<!--maximum thrust output of the propeller at sea level for varying velocities--></thrust_limit>
+        </sea_level>
+      </propeller>
+      <slipstream>
+        <wing>
+          <cruise>
+            <prop_on>
+              <Y_vector units="m" is_input="True">[0.055575258464038636, 0.16672577539211592, 0.2778633013761857, 0.38901381830426296, 0.5001643352323403, 0.61130186121641, 0.7224523781444873, 0.8567917301259327, 1.0147746002010083, 1.1736538454126009, 1.3333255382086504, 1.4936987419811039, 1.6546825201219095, 1.8161729450790076, 1.9780660893003374, 2.140271016177847, 2.302696789103484, 2.465213498637173, 2.6277561900588777, 2.790181962984515, 2.9524258626940467, 3.1143709706914064, 3.2759263503685423, 3.436975083229385, 3.5974392236098915, 3.7572148439580006, 3.916198016721653, 4.074310796236803, 4.2314622458954, 4.38756142908939, 4.542504418266713, 4.69623924965134, 4.84866199569121, 4.999707701666287, 5.149285430968517, 5.297356210765878, 5.443816113506312, 5.588626166357793, 5.731721414600286, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]<!--wing station along the wing span at which chord_vector and Cl_vector are sampled--></Y_vector>
+              <velocity units="knot" is_input="True">93.0</velocity>
+            </prop_on>
+            <only_prop>
+              <CL_vector is_input="True">[0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]</CL_vector>
+            </only_prop>
+          </cruise>
+        </wing>
+      </slipstream>
+    </aerodynamics>
+    <mission>
+      <sizing>
+        <initial_climb>
+          <energy units="W*h" is_input="True">0.0<!--mass of consumed fuel during initial climb phase in sizing mission--></energy>
+          <fuel units="kg" is_input="True">0.0<!--mass of consumed fuel during initial climb phase in sizing mission--></fuel>
+        </initial_climb>
+        <landing>
+          <elevator_angle units="deg" is_input="True">-40.0<!--position of the elevator during landing--></elevator_angle>
+          <flap_angle units="deg" is_input="True">19.0<!--flap angle during landing phase in sizing mission--></flap_angle>
+          <target_sideslip units="deg" is_input="True">12.0</target_sideslip>
+        </landing>
+        <takeoff>
+          <elevator_angle units="deg" is_input="True">-40.0<!--position of the elevator during takeoff--></elevator_angle>
+          <energy units="W*h" is_input="True">0.0<!--mass of consumed fuel during initial climb phase in sizing mission--></energy>
+          <flap_angle units="deg" is_input="True">9.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
+          <fuel units="kg" is_input="True">0.0<!--mass of consumed fuel during takeoff phase in sizing mission--></fuel>
+          <thrust_rate is_input="True">1.0<!--thrust rate during takeoff phase--></thrust_rate>
+        </takeoff>
+        <taxi_in>
+          <duration units="s" is_input="True">150.0<!--duration of taxi-in phase in sizing mission--></duration>
+          <speed units="knot" is_input="True">20.0<!--speed during taxi-in phase in sizing mission--></speed>
+        </taxi_in>
+        <taxi_out>
+          <duration units="s" is_input="True">150.0<!--duration of taxi-out phase in sizing mission--></duration>
+          <speed units="knot" is_input="True">20.0<!--speed during taxi-out phase in sizing mission--></speed>
+        </taxi_out>
+        <cs23>
+          <sizing_factor>
+            <ultimate_aircraft is_input="True">6.0<!--ultimate load factor that the aircraft will experience (default value is 5.7)--></ultimate_aircraft>
+            <ultimate_mtow>
+              <negative>-3.0</negative>
+              <positive>6.0</positive>
+            </ultimate_mtow>
+            <ultimate_mzfw>
+              <negative>-3.0</negative>
+              <positive>6.0</positive>
+            </ultimate_mzfw>
+          </sizing_factor>
+          <safety_factor>1.5</safety_factor>
+          <characteristic_speed>
+            <va units="knot">86.0</va>
+            <vc units="knot">93.0</vc>
+            <vd units="knot">135.0</vd>
+          </characteristic_speed>
+        </cs23>
+        <main_route>
+          <climb>
+            <v_eas units="m/s" is_input="True">38.0</v_eas> <!--75 KIAS-->
+            <climb_rate>
+              <cruise_level units="ft/min" is_input="True">610.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min" is_input="True">650.0<!--target climb rate at sea level--></sea_level>
+            </climb_rate>
+          </climb>
+          <cruise>
+            <altitude units="ft" is_input="True">2000.0<!--altitude during cruise phase in sizing mission--></altitude>
+          </cruise>
+          <descent>
+            <descent_rate units="ft/min" is_input="True">-450.0<!--target descent rate for the
+            aircraft--></descent_rate>
+            <v_eas units="m/s" is_input="True">35.0</v_eas>
+          </descent>
+          <reserve>
+            <altitude units="ft" is_input="True">1000.0<!--altitude of the reserve segment--></altitude>
+            <duration units="min" is_input="True">30.0<!--duration of the reserve segment--></duration>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+  </data>
+  <settings>
+    <geometry>
+      <fuel_tanks>
+        <depth>0.5</depth>
+      </fuel_tanks>
+    </geometry>
+    <handling_qualities>
+      <rudder>
+        <safety_margin is_input="True">0.25<!--Ratio of the total rudder deflection not used in the computation of the VT area to leave a safety margin--></safety_margin>
+      </rudder>
+    </handling_qualities>
+    <propulsion>
+      <IC_engine>
+        <k_factor_sfc is_input="True">1.0<!--k_factor that can be used to adjust the consumption on engine level to the aircraft level--></k_factor_sfc>
+      </IC_engine>
+      <he_power_train>
+        <PMSM>
+          <motor_1>
+            <k_efficiency is_input="True">0.937<!--K factor for the PMSM efficiency--></k_efficiency>
+          </motor_1>
+        </PMSM>
+        <DC_bus>
+          <insulation>
+            <breakdown_voltage units="V" is_input="True">340.0<!--Mininum breakdown voltage of air cavity--></breakdown_voltage>
+            <density units="kg/m**3" is_input="True">1450.0<!--Density of the insulation, Gexol is assumed--></density>
+            <dielectric_permittivity is_input="True">4.0<!--Dielectric permittivity of the insulation, chosen as Gexol insulation--></dielectric_permittivity>
+            <void_thickness units="m" is_input="True">5e-05</void_thickness>
+          </insulation>
+        </DC_bus>
+        <DC_cable_harness>
+          <insulation>
+            <breakdown_voltage units="V" is_input="True">340.0<!--Minimum breakdown voltage of air cavity--></breakdown_voltage>
+            <density units="kg/m**3" is_input="True">1450.0</density>
+            <dielectric_permittivity is_input="True">4.0<!--Dielectric permittivity of the insulation, chosen as Gexol insulation--></dielectric_permittivity>
+            <specific_heat units="J/kg/degK" is_input="True">2800.0</specific_heat>
+            <void_thickness units="m" is_input="True">5e-05</void_thickness>
+          </insulation>
+          <sheath>
+            <density units="kg/m**3" is_input="True">950.0<!--High density polyethylene for cable sheath--></density>
+            <specific_heat units="J/kg/degK" is_input="True">1550.0<!--High density polyethylene for cable sheath--></specific_heat>
+          </sheath>
+          <shielding_tape>
+            <density units="kg/m**3" is_input="True">8960.0<!--High density polyethylene for cable sheath--></density>
+            <specific_heat units="J/kg/degK" is_input="True">386.0<!--Copper used for shielding tape--></specific_heat>
+            <thickness units="m" is_input="True">0.0002</thickness>
+          </shielding_tape>
+        </DC_cable_harness>
+        <inverter>
+          <inverter_1>
+            <casing>
+              <specific_heat units="J/kg/degK" is_input="True">600.0<!--Equivalent specific heat capacity of the casing--></specific_heat>
+            </casing>
+          </inverter_1>
+        </inverter>
+      </he_power_train>
+    </propulsion>
+    <weight>
+      <aircraft>
+        <MLW_MZFW_ratio is_input="True">1.06</MLW_MZFW_ratio>
+        <CG>
+          <range is_input="True">0.074<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+          <aft>
+            <MAC_position>
+              <margin is_input="True">0.05<!--safety margin aft of the most aft X-position of center of gravity as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </aft>
+          <fwd>
+            <MAC_position>
+              <margin is_input="True">0.03<!--safety margin fwd of the most fwd X-position of center of gravity as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </fwd>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg" is_input="True">80.0<!--design payload mass carried by passenger--></design_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <landing_gear>
+          <front>
+            <weight_ratio is_input="True">0.25<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+          </front>
+        </landing_gear>
+      </airframe>
+      <propulsion>
+        <tank>
+          <CG>
+            <from_wingMAC25 is_input="True">0.25<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
+          </CG>
+        </tank>
+      </propulsion>
+    </weight>
+    <mission>
+      <sizing>
+        <main_route>
+          <reserve>
+            <speed>
+              <k_factor is_input="True">1.38<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+            </speed>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+    <wing>
+      <structure>
+        <F_COMP>1.0</F_COMP>
+      </structure>
+    </wing>
+  </settings>
+  <convergence>
+    <propulsion>
+      <he_power_train>
+        <propeller>
+          <propeller_1>
+            <min_power units="kW">5.0</min_power>
+          </propeller_1>
+        </propeller>
+      </he_power_train>
+    </propulsion>
+  </convergence>
+</FASTOAD_model>

--- a/integration_tests/pipistrel/pipistrel_lower_soc_start_viz.ipynb
+++ b/integration_tests/pipistrel/pipistrel_lower_soc_start_viz.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "79d8b714-e3bc-4622-b1c1-574bcbb4e462",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Pipistrel Velis Club"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path as pth\n",
+    "import logging\n",
+    "\n",
+    "import fastga_he.api as oad_he\n",
+    "\n",
+    "DATA_FOLDER_PATH = \"data\"\n",
+    "\n",
+    "RESULTS_FOLDER_PATH = \"results\"\n",
+    "\n",
+    "CONFIGURATION_FILE = pth.join(DATA_FOLDER_PATH, \"pipistrel_lower_soc_start_configuration.yml\")\n",
+    "PT_FILE = pth.join(DATA_FOLDER_PATH, \"pipistrel_assembly_lower_soc_start.yml\")\n",
+    "# The following PT file is not used for sizing just to try out the network function\n",
+    "SOURCE_FILE = pth.join(DATA_FOLDER_PATH, \"pipistrel_source_lower_soc_start.xml\")\n",
+    "\n",
+    "# For having log messages on screen\n",
+    "logging.basicConfig(level=logging.WARNING, format=\"%(levelname)-8s: %(message)s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "faa74a3c-7990-48c4-bb19-2f209b0e6af0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import IFrame\n",
+    "\n",
+    "NETWORK_FILE = pth.join(RESULTS_FOLDER_PATH, \"pipistrel_assembly.html\")\n",
+    "\n",
+    "oad_he.power_train_network_viewer(power_train_file_path=PT_FILE, network_file_path=NETWORK_FILE)\n",
+    "\n",
+    "# For some reason, this doesn't display icon. Opening it in Firefox does the trick.\n",
+    "IFrame(src=NETWORK_FILE, width=\"100%\", height=\"500px\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a649c3-22b6-4e5b-8bf2-ce924c36a38a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"mission_data_lower_soc_start.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"pipistrel_power_train_data_lower_soc_start.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5955f012-6fc3-42c1-b36e-0b85ab8759cd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/integration_tests/pipistrel/test_sizing_pipistrel.py
+++ b/integration_tests/pipistrel/test_sizing_pipistrel.py
@@ -89,6 +89,64 @@ def test_pipistrel_velis_electro():
     assert sizing_energy == pytest.approx(25.05, abs=1e-2)
 
 
+def test_pipistrel_velis_electro_lower_soc_start_mission():
+    """Test the overall aircraft design process with wing positioning under VLM method."""
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+    logging.getLogger("bw2data").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "pipistrel_source_lower_soc_start.xml"
+    process_file_name = "pipistrel_lower_soc_start_configuration.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, process_file_name))
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = pth.join(DATA_FOLDER_PATH, xml_file_name)
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    # Give good initial guess on a few key value to reduce the time it takes to converge
+    problem.set_val("data:weight:aircraft:MTOW", units="kg", val=600.0)
+    problem.set_val("data:weight:aircraft:OWE", units="kg", val=400.0)
+    problem.set_val("data:weight:aircraft:MZFW", units="kg", val=600.0)
+    problem.set_val("data:weight:aircraft:ZFW", units="kg", val=600.0)
+    problem.set_val("data:weight:aircraft:MLW", units="kg", val=600.0)
+
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:SOC_mission_start",
+        units="percent",
+        val=80.0,
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_2:SOC_mission_start",
+        units="percent",
+        val=80.0,
+    )
+
+    # Run the problem
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.output_file_path = pth.join(RESULTS_FOLDER_PATH, "pipistrel_lower_soc_start_out.xml")
+    problem.write_outputs()
+
+    assert problem.get_val("data:weight:aircraft:MTOW", units="kg") == pytest.approx(
+        650.00, rel=1e-2
+    )
+    sizing_energy = problem.get_val("data:mission:sizing:energy", units="kW*h")
+    assert sizing_energy == pytest.approx(25.94, abs=1e-2)
+    # vs 25 kWh with the classic aircraft, so the increase is due to the increased weight and not
+    # the decreased SOC start
+
+
 def test_pipistrel_heavy_velis_electro():
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("fastoad.module_management._bundle_loader").disabled = True

--- a/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_energy_consumed_main_route.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_energy_consumed_main_route.py
@@ -48,7 +48,7 @@ class PerformancesEnergyConsumedMainRoute(om.ExplicitComponent):
             + ":energy_consumed_main_route",
             units="W*h",
             val=50e3,
-            desc="Energy drawn from the battery for the mission",
+            desc="Energy drawn from the battery for the main route of the missions (excludes reserve)",
         )
 
         val_partial = np.ones(number_of_points)

--- a/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_pack.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_pack.py
@@ -28,6 +28,7 @@ from ..components.perf_battery_efficiency import PerformancesBatteryEfficiency
 from ..components.perf_energy_consumption import PerformancesEnergyConsumption
 from ..components.perf_battery_energy_consumed import PerformancesEnergyConsumed
 from ..components.perf_battery_energy_consumed_main_route import PerformancesEnergyConsumedMainRoute
+from ..components.perf_soc_end_main_route import PerformancesSOCEndMainRoute
 from ..components.perf_inflight_emissions import PerformancesBatteryPackInFlightEmissions
 
 
@@ -201,6 +202,15 @@ class PerformancesBatteryPack(om.Group):
             self.add_subsystem(
                 "energy_consumed_main_route",
                 PerformancesEnergyConsumedMainRoute(
+                    number_of_points=number_of_points,
+                    battery_pack_id=battery_pack_id,
+                    number_of_points_reserve=number_of_points_reserve,
+                ),
+                promotes=["*"],
+            )
+            self.add_subsystem(
+                "soc_end_route",
+                PerformancesSOCEndMainRoute(
                     number_of_points=number_of_points,
                     battery_pack_id=battery_pack_id,
                     number_of_points_reserve=number_of_points_reserve,

--- a/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_pack.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/perf_battery_pack.py
@@ -104,7 +104,9 @@ class PerformancesBatteryPack(om.Group):
         )
         self.add_subsystem(
             "update_soc",
-            PerformancesUpdateSOC(number_of_points=number_of_points),
+            PerformancesUpdateSOC(
+                number_of_points=number_of_points, battery_pack_id=battery_pack_id
+            ),
             promotes=["*"],
         )
         # Though these variable depends on variables that are looped on, they don't affect the

--- a/src/fastga_he/models/propulsion/components/source/battery/components/perf_soc_end_main_route.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/perf_soc_end_main_route.py
@@ -1,0 +1,70 @@
+#  This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
+#  Electric Aircraft.
+#  Copyright (C) 2025 ISAE-SUPAERO
+
+
+import openmdao.api as om
+import numpy as np
+
+
+class PerformancesSOCEndMainRoute(om.ExplicitComponent):
+    """
+    Identification of the state of charge at the end of the main route.
+    """
+
+    def initialize(self):
+        self.options.declare(
+            "number_of_points", default=1, desc="number of equilibrium to be treated"
+        )
+        # Default is set as None, because at group level if the option isn't set this component
+        # shouldn't be added, so it is a second safety
+        self.options.declare(
+            "number_of_points_reserve",
+            default=None,
+            desc="number of equilibrium to be treated in reserve",
+            types=int,
+        )
+        self.options.declare(
+            name="battery_pack_id",
+            default=None,
+            desc="Identifier of the battery pack",
+            allow_none=False,
+        )
+
+    def setup(self):
+        number_of_points = self.options["number_of_points"]
+        number_of_points_reserve = self.options["number_of_points_reserve"]
+        battery_pack_id = self.options["battery_pack_id"]
+
+        self.add_input("state_of_charge", units="percent", val=np.full(number_of_points, np.nan))
+
+        self.add_output(
+            "data:propulsion:he_power_train:battery_pack:"
+            + battery_pack_id
+            + ":SOC_end_main_route",
+            units="percent",
+            val=20,
+            desc="State of charge at the end of the main route (excludes reserve)",
+        )
+
+        partials_soc = np.zeros(number_of_points)
+        partials_soc[-number_of_points_reserve - 2] = 1
+
+        self.declare_partials(
+            of="data:propulsion:he_power_train:battery_pack:"
+            + battery_pack_id
+            + ":SOC_end_main_route",
+            wrt="state_of_charge",
+            method="exact",
+            rows=np.zeros(number_of_points),
+            cols=np.arange(number_of_points),
+            val=partials_soc,
+        )
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        number_of_points_reserve = self.options["number_of_points_reserve"]
+        battery_pack_id = self.options["battery_pack_id"]
+
+        outputs[
+            "data:propulsion:he_power_train:battery_pack:" + battery_pack_id + ":SOC_end_main_route"
+        ] = inputs["state_of_charge"][-number_of_points_reserve - 2]

--- a/src/fastga_he/models/propulsion/components/source/battery/components/perf_update_soc.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/components/perf_update_soc.py
@@ -16,12 +16,25 @@ class PerformancesUpdateSOC(om.ExplicitComponent):
         self.options.declare(
             "number_of_points", default=1, desc="number of equilibrium to be treated"
         )
+        self.options.declare(
+            name="battery_pack_id",
+            default=None,
+            desc="Identifier of the battery pack",
+            allow_none=False,
+        )
 
     def setup(self):
         number_of_points = self.options["number_of_points"]
+        battery_pack_id = self.options["battery_pack_id"]
 
         self.add_input(
             "state_of_charge_decrease", units="percent", val=np.full(number_of_points, np.nan)
+        )
+        self.add_input(
+            "data:propulsion:he_power_train:battery_pack:" + battery_pack_id + ":SOC_mission_start",
+            val=100.0,
+            units="percent",
+            desc="State-of-Charge of the battery at the start of the mission",
         )
 
         self.add_output("state_of_charge", units="percent", val=np.full(number_of_points, 100.0))
@@ -36,10 +49,25 @@ class PerformancesUpdateSOC(om.ExplicitComponent):
             rows=np.where(partials == -1)[0],
             cols=np.where(partials == -1)[1],
         )
+        self.declare_partials(
+            of="state_of_charge",
+            wrt="data:propulsion:he_power_train:battery_pack:"
+            + battery_pack_id
+            + ":SOC_mission_start",
+            method="exact",
+            rows=np.arange(number_of_points),
+            cols=np.zeros(number_of_points),
+            val=np.ones(number_of_points),
+        )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         number_of_points = self.options["number_of_points"]
+        battery_pack_id = self.options["battery_pack_id"]
 
-        outputs["state_of_charge"] = np.full(number_of_points, 100.0) - np.cumsum(
+        soc_mission_start = inputs[
+            "data:propulsion:he_power_train:battery_pack:" + battery_pack_id + ":SOC_mission_start"
+        ]
+
+        outputs["state_of_charge"] = np.full(number_of_points, soc_mission_start) - np.cumsum(
             np.concatenate((np.zeros(1), inputs["state_of_charge_decrease"][:-1]))
         )

--- a/src/fastga_he/models/propulsion/components/source/battery/unit_tests/test_battery.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/unit_tests/test_battery.py
@@ -41,6 +41,7 @@ from ..components.perf_battery_power import PerformancesBatteryPower
 from ..components.perf_energy_consumption import PerformancesEnergyConsumption
 from ..components.perf_battery_energy_consumed import PerformancesEnergyConsumed
 from ..components.perf_battery_energy_consumed_main_route import PerformancesEnergyConsumedMainRoute
+from ..components.perf_soc_end_main_route import PerformancesSOCEndMainRoute
 from ..components.cstr_ensure import ConstraintsSOCEnsure
 from ..components.cstr_enforce import ConstraintsSOCEnforce
 from ..components.pre_lca_prod_weight_per_fu import PreLCABatteryProdWeightPerFU
@@ -1071,6 +1072,27 @@ def test_energy_consumed_main_route():
         "data:propulsion:he_power_train:battery_pack:battery_pack_1:energy_consumed_main_route",
         units="kW*h",
     ) == pytest.approx(339.86, rel=1e-2)
+
+    problem.check_partials(compact_print=True)
+
+
+def test_soc_end_main_route():
+    ivc = om.IndepVarComp()
+    ivc.add_output("state_of_charge", val=np.linspace(100, 40, NB_POINTS_TEST), units="percent")
+
+    # Run problem and check obtained value(s) is/(are) correct
+    problem = run_system(
+        PerformancesSOCEndMainRoute(
+            number_of_points=NB_POINTS_TEST,
+            battery_pack_id="battery_pack_1",
+            number_of_points_reserve=2,
+        ),
+        ivc,
+    )
+    assert problem.get_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:SOC_end_main_route",
+        units="percent",
+    ) == pytest.approx(60.0, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/source/battery/unit_tests/test_battery.py
+++ b/src/fastga_he/models/propulsion/components/source/battery/unit_tests/test_battery.py
@@ -732,11 +732,26 @@ def test_update_soc():
 
     # Run problem and check obtained value(s) is/(are) correct
     problem = run_system(
-        PerformancesUpdateSOC(number_of_points=NB_POINTS_TEST),
+        PerformancesUpdateSOC(number_of_points=NB_POINTS_TEST, battery_pack_id="battery_pack_1"),
         ivc,
     )
     assert problem.get_val("state_of_charge", units="percent") == pytest.approx(
         [100.0, 93.06, 86.09, 79.1, 72.1, 65.08, 58.04, 50.98, 43.9, 36.8],
+        rel=1e-2,
+    )
+
+    problem.check_partials(compact_print=True)
+
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:SOC_mission_start",
+        units="percent",
+        val=80.0,
+    )
+
+    problem.run_model()
+
+    assert problem.get_val("state_of_charge", units="percent") == pytest.approx(
+        [80.0, 73.06, 66.09, 59.1, 52.1, 45.08, 38.04, 30.98, 23.9, 16.8],
         rel=1e-2,
     )
 


### PR DESCRIPTION
Added a way to choos which SoC the battery starts the mission at. Default will be 100 for retrocompatibility. Also added a variable that identify the SOC at the end of the main route. Both will be useful in the next PR