### PR TITLE
Cirrus SR22 new test cases

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -661,3 +661,13 @@ URL = {https://doi.org/10.2514/1.C038004},
   booktitle={Aerospace Europe Conference 2023--10ᵀᴴ EUCASS--9ᵀᴴ CEAS},
   year={2023}
 }
+
+@article{brooker:2006,
+  title={Civil aircraft design priorities: air quality? climate change? noise?},
+  volume={110}, DOI={10.1017/S0001924000001408},
+  number={1110},
+  journal={The Aeronautical Journal (1968)},
+  author={Brooker, P.},
+  year={2006},
+  pages={517–532}
+}

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -123,9 +123,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "321d1a4d-06a7-422c-a379-09e9b57eb796",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Hybrid SR22 with power share"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "81021fd8-bbe3-42f9-8e1b-c835a3375a04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_power_share.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_power_share.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2925175-88df-481f-a959-85e9ee2e5568",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -5,12 +5,12 @@
    "id": "79d8b714-e3bc-4622-b1c1-574bcbb4e462",
    "metadata": {},
    "source": [
-    "# Data visualization for the Electric Cirrus SR22"
+    "# Data visualization for the Cirrus SR22"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
    "metadata": {},
    "outputs": [],
@@ -26,6 +26,60 @@
     "\n",
     "# For having log messages on screen\n",
     "logging.basicConfig(level=logging.WARNING, format=\"%(levelname)-8s: %(message)s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c637fdf9-ef3a-408c-b2c1-9deb8665ef79",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c84e413a476d4187b11f6df2dd1d3a9c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='x:'), Dropdown(index=31, options=('propeller_1 rpm [1/min]', 'propeller_1 shaft_po…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ffc358d8477842e88c611275bdc98dfb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"fuel_propulsion.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"fuel_propulsion_pt_watcher.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27ef2346-6003-4d1b-99fc-1418983223d4",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Electric Cirrus SR22"
    ]
   },
   {

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -220,8 +220,41 @@
    "source": [
     "BETTER_CELLS_RESULTS_FOLDER_PATH = \"results_better_cells\"\n",
     "\n",
-    "MISSION_DATA_FILE = pth.join(BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_no_LTO_improved.csv\")\n",
-    "PT_DATA_FILE = pth.join(BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_no_LTO_improved.csv\")\n",
+    "MISSION_DATA_FILE = pth.join(\n",
+    "    BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_no_LTO_improved.csv\"\n",
+    ")\n",
+    "PT_DATA_FILE = pth.join(\n",
+    "    BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_no_LTO_improved.csv\"\n",
+    ")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e25cc499-3293-4e36-89dc-c29bff10ffc9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Data visualization for the Hybrid SR22 on the op mission"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fca544d-2a36-4b37-bb22-ef1c7fcd7b7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BETTER_CELLS_RESULTS_FOLDER_PATH = \"results_better_cells\"\n",
+    "\n",
+    "MISSION_DATA_FILE = pth.join(BETTER_CELLS_RESULTS_FOLDER_PATH, \"fuel_propulsion_op_mission.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher.csv\")\n",
     "\n",
     "perfo_viewer = oad_he.PerformancesViewer(\n",
     "    power_train_data_file_path=PT_DATA_FILE,\n",
@@ -233,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fca544d-2a36-4b37-bb22-ef1c7fcd7b7f",
+   "id": "a37b523f-0193-4b8c-a9fa-f4c9d3eb9af3",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "79d8b714-e3bc-4622-b1c1-574bcbb4e462",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Pipistrel Velis Club"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path as pth\n",
+    "import logging\n",
+    "\n",
+    "import fastga_he.api as oad_he\n",
+    "\n",
+    "DATA_FOLDER_PATH = \"data\"\n",
+    "\n",
+    "RESULTS_FOLDER_PATH = \"results\"\n",
+    "\n",
+    "# For having log messages on screen\n",
+    "logging.basicConfig(level=logging.WARNING, format=\"%(levelname)-8s: %(message)s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a649c3-22b6-4e5b-8bf2-ce924c36a38a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"electric_propulsion.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"cirrus_sr22_electric.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -148,9 +148,63 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "27705d64-abfb-4fce-a11b-fd9bde95d05e",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Hybrid SR22 with no LTO emissions"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2925175-88df-481f-a959-85e9ee2e5568",
+   "id": "46a82882-61b5-4e01-8799-44f65ff12eb8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_no_LTO.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_no_LTO.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dfbe143-469e-44f7-b81b-17719f41891d",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Hybrid SR22 with no LTO emissions improved"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b004a22d-98fc-4c2e-805c-82f3a8515fbb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_no_LTO_improved.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_no_LTO_improved.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89a4785d-30a4-4581-af08-07db028e44f5",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
    "metadata": {},
    "outputs": [],
@@ -30,39 +30,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c637fdf9-ef3a-408c-b2c1-9deb8665ef79",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c84e413a476d4187b11f6df2dd1d3a9c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Label(value='x:'), Dropdown(index=31, options=('propeller_1 rpm [1/min]', 'propeller_1 shaft_po…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ffc358d8477842e88c611275bdc98dfb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"fuel_propulsion.csv\")\n",
     "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"fuel_propulsion_pt_watcher.csv\")\n",
@@ -127,9 +98,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bbb552c0-43a8-4037-9bb8-861d20cee213",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Hybrid SR22"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0d449aba-42cd-4352-8b2b-98702b56fa02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81021fd8-bbe3-42f9-8e1b-c835a3375a04",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -5,12 +5,12 @@
    "id": "79d8b714-e3bc-4622-b1c1-574bcbb4e462",
    "metadata": {},
    "source": [
-    "# Data visualization for the Pipistrel Velis Club"
+    "# Data visualization for the Electric Cirrus SR22"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
    "metadata": {},
    "outputs": [],
@@ -44,6 +44,70 @@
     "    plot_height=800,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f71ff92f-104c-4c96-ba2e-31b81106bc0e",
+   "metadata": {},
+   "source": [
+    "# Data visualization for the Electric Cirrus SR22 with two stacked motors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6b6b3ba9-f11c-456b-a626-fdc132b29f52",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3dac3916df94692a9d7127481f955cd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='x:'), Dropdown(index=104, options=('propeller_1 rpm [1/min]', 'propeller_1 shaft_p…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "197e9d81281a4314b5882160f413b4c5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"electric_propulsion_two_motors.csv\")\n",
+    "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"cirrus_sr22_electric_two_motors.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d449aba-42cd-4352-8b2b-98702b56fa02",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -202,9 +202,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c8ad885a-57cf-4e14-8962-4fa5aefd0816",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Data visualization for the Hybrid SR22 with no LTO emissions improved with better cells"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "89a4785d-30a4-4581-af08-07db028e44f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BETTER_CELLS_RESULTS_FOLDER_PATH = \"results_better_cells\"\n",
+    "\n",
+    "MISSION_DATA_FILE = pth.join(BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_no_LTO_improved.csv\")\n",
+    "PT_DATA_FILE = pth.join(BETTER_CELLS_RESULTS_FOLDER_PATH, \"hybrid_propulsion_pt_watcher_no_LTO_improved.csv\")\n",
+    "\n",
+    "perfo_viewer = oad_he.PerformancesViewer(\n",
+    "    power_train_data_file_path=PT_DATA_FILE,\n",
+    "    mission_data_file_path=MISSION_DATA_FILE,\n",
+    "    plot_height=800,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fca544d-2a36-4b37-bb22-ef1c7fcd7b7f",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
+++ b/integration_tests/cirrus_sr22/cirrus_data_viz.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "961523bf-f072-4dfd-a70e-2f6556070ad9",
    "metadata": {},
    "outputs": [],
@@ -55,41 +55,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6b6b3ba9-f11c-456b-a626-fdc132b29f52",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e3dac3916df94692a9d7127481f955cd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Label(value='x:'), Dropdown(index=104, options=('propeller_1 rpm [1/min]', 'propeller_1 shaft_p…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "197e9d81281a4314b5882160f413b4c5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MISSION_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"electric_propulsion_two_motors.csv\")\n",
     "PT_DATA_FILE = pth.join(RESULTS_FOLDER_PATH, \"cirrus_sr22_electric_two_motors.csv\")\n",

--- a/integration_tests/cirrus_sr22/data/electric_propulsion.yml
+++ b/integration_tests/cirrus_sr22/data/electric_propulsion.yml
@@ -1,0 +1,75 @@
+title: Powertrain file for the electric version of the SR22
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+    position: from_rear_to_front  # "inside_the_wing", "from_rear_to_front", "from_rear_to_wing", "from_front_to_wing", "from_rear_to_nose", "from_front_to_nose", "from_wing_to_nose"
+
+  dc_splitter_1:
+    id: fastga_he.pt_component.dc_splitter
+    position: in_the_back  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: inside_the_wing
+  battery_pack_1:
+    id: fastga_he.pt_component.battery_pack
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+  dc_sspc_2:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: inside_the_wing
+    symmetrical: dc_sspc_1
+  battery_pack_2:
+    id: fastga_he.pt_component.battery_pack
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+    symmetrical: battery_pack_1
+
+component_connections:
+  - source: propeller_1
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: [dc_bus_1, 1]
+
+  - source: [dc_bus_1, 1]
+    target: harness_1
+
+  - source: harness_1
+    target: dc_splitter_1
+
+  - source: [dc_splitter_1, 1]
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: battery_pack_1
+
+  - source: [dc_splitter_1, 2 ]
+    target: dc_sspc_2
+
+  - source: dc_sspc_2
+    target: battery_pack_2
+
+watcher_file_path: ../results/cirrus_sr22_electric.csv

--- a/integration_tests/cirrus_sr22/data/electric_propulsion_two_motors.yml
+++ b/integration_tests/cirrus_sr22/data/electric_propulsion_two_motors.yml
@@ -1,0 +1,104 @@
+title: Powertrain file for the electric version of the SR22
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+
+  planetary_gear_1:
+    id: fastga_he.pt_component.planetary_gear
+    position: in_the_front
+    options:
+      gear_mode: percent_split
+
+
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  motor_2:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_2:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+
+
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 2
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+    position: from_rear_to_front  # "inside_the_wing", "from_rear_to_front", "from_rear_to_wing", "from_front_to_wing", "from_rear_to_nose", "from_front_to_nose", "from_wing_to_nose"
+
+  dc_splitter_1:
+    id: fastga_he.pt_component.dc_splitter
+    position: in_the_back  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: inside_the_wing
+  battery_pack_1:
+    id: fastga_he.pt_component.battery_pack
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+  dc_sspc_2:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: inside_the_wing
+    symmetrical: dc_sspc_1
+  battery_pack_2:
+    id: fastga_he.pt_component.battery_pack
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+    symmetrical: battery_pack_1
+
+component_connections:
+  - source: propeller_1
+    target: planetary_gear_1
+
+  - source: [planetary_gear_1, 1]
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: [dc_bus_1, 1]
+
+  - source: [planetary_gear_1, 2]
+    target: motor_2
+
+  - source: motor_2
+    target: inverter_2
+
+  - source: inverter_2
+    target: [dc_bus_1, 2]
+
+  - source: [dc_bus_1, 1]
+    target: harness_1
+
+  - source: harness_1
+    target: dc_splitter_1
+
+  - source: [dc_splitter_1, 1]
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: battery_pack_1
+
+  - source: [dc_splitter_1, 2 ]
+    target: dc_sspc_2
+
+  - source: dc_sspc_2
+    target: battery_pack_2
+
+watcher_file_path: ../results/cirrus_sr22_electric_two_motors.csv

--- a/integration_tests/cirrus_sr22/data/full_sizing_electric.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_electric.yml
@@ -11,7 +11,7 @@ output_file: ../results/full_sizing_elec_out.xml
 driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=20, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=20, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy

--- a/integration_tests/cirrus_sr22/data/full_sizing_electric.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_electric.yml
@@ -1,0 +1,88 @@
+title: Sample OAD Process
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/full_sizing_elec_in.xml
+output_file: ../results/full_sizing_elec_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
+
+model:
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=20, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  linear_solver: om.LinearBlockGS()
+  geometry:
+    id: fastga.geometry.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  aerodynamics_lowspeed:
+    id: fastga.aerodynamics.lowspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path : ../workdir
+    compute_slipstream : false
+  aerodynamics_highspeed:
+    id: fastga.aerodynamics.highspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path: ../workdir
+    compute_mach_interpolation: false
+    compute_slipstream: false
+  power_train_sizing:
+    id: fastga_he.power_train.sizing
+    power_train_file_path: ./electric_propulsion.yml
+  weight:
+    id: fastga.weight.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  performances:
+    id: fastga_he.performances.mission_vector
+    number_of_points_climb: 30
+    number_of_points_cruise: 30
+    number_of_points_descent: 20
+    number_of_points_reserve: 10
+    power_train_file_path: ./electric_propulsion.yml
+    out_file: ../results/electric_propulsion.csv
+    use_linesearch: False
+    pre_condition_pt: False
+    use_apply_nonlinear: False
+  mtow:
+    id: fastga.loop.mtow
+  hq:
+    tail_sizing:
+      id: fastga.handling_qualities.tail_sizing
+      propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    static_margin:
+      id: fastga.handling_qualities.static_margin
+  wing_position:
+    id: fastga.loop.wing_position
+  wing_area:
+    id: fastga.loop.wing_area
+#    power_train_file_path: ./fuel_propulsion.yml
+
+submodels:
+  submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null
+  service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
+  service.weight.mass.system.power_system: null
+  service.geometry.nacelle.dimension: null
+  service.geometry.vertical_tail.distance.fd: null
+  service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+
+optimization: # This section is needed only if optimization process is run
+  design_variables:
+    - name: data:propulsion:he_power_train:propeller:propeller_1:solidity
+      lower: 0.1
+      upper: 0.4
+    - name: data:propulsion:he_power_train:propeller:propeller_1:activity_factor
+      lower: 50
+      upper: 250
+    - name: data:propulsion:he_power_train:propeller:propeller_1:blade_twist
+      lower: 10
+      upper: 35
+  objective:
+    - name: data:mission:sizing:energy
+      scaler: 1.e-4

--- a/integration_tests/cirrus_sr22/data/full_sizing_electric_two_motors.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_electric_two_motors.yml
@@ -60,7 +60,7 @@ model:
 submodels:
   submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
   submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
-  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.ensure
   submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
   submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
   submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce

--- a/integration_tests/cirrus_sr22/data/full_sizing_electric_two_motors.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_electric_two_motors.yml
@@ -1,0 +1,72 @@
+title: Sample OAD Process
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/full_sizing_elec_in_two_motors.xml
+output_file: ../results/full_sizing_elec_out_two_motors.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
+
+model:
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=50, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8)
+  linear_solver: om.LinearBlockGS()
+  geometry:
+    id: fastga.geometry.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  aerodynamics_lowspeed:
+    id: fastga.aerodynamics.lowspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path : ../workdir
+    compute_slipstream : false
+  aerodynamics_highspeed:
+    id: fastga.aerodynamics.highspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path: ../workdir
+    compute_mach_interpolation: false
+    compute_slipstream: false
+  power_train_sizing:
+    id: fastga_he.power_train.sizing
+    power_train_file_path: ./electric_propulsion_two_motors.yml
+  weight:
+    id: fastga.weight.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  performances:
+    id: fastga_he.performances.mission_vector
+    number_of_points_climb: 30
+    number_of_points_cruise: 30
+    number_of_points_descent: 20
+    number_of_points_reserve: 10
+    power_train_file_path: ./electric_propulsion_two_motors.yml
+    out_file: ../results/electric_propulsion_two_motors.csv
+    use_linesearch: False
+    pre_condition_pt: False
+    use_apply_nonlinear: False
+  mtow:
+    id: fastga.loop.mtow
+  hq:
+    tail_sizing:
+      id: fastga.handling_qualities.tail_sizing
+      propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    static_margin:
+      id: fastga.handling_qualities.static_margin
+  wing_position:
+    id: fastga.loop.wing_position
+  wing_area:
+    id: fastga.loop.wing_area
+
+submodels:
+  submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null
+  service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
+  service.weight.mass.system.power_system: null
+  service.geometry.nacelle.dimension: null
+  service.geometry.vertical_tail.distance.fd: null
+  service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
@@ -74,6 +74,7 @@ submodels:
   service.geometry.nacelle.dimension: null
   service.geometry.vertical_tail.distance.fd: null
   service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+  submodel.performances.mission_vector.reserve_speed: null
 
 optimization: # This section is needed only if optimization process is run
   design_variables:

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
@@ -11,7 +11,7 @@ output_file: ../results/full_sizing_hybrid_out.xml
 driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-8, atol=1, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
@@ -57,6 +57,8 @@ model:
   wing_area:
     id: fastga.loop.wing_area
 #    power_train_file_path: ./fuel_propulsion.yml
+  environmental_impact:
+    id: fastga_he.environmental.energy_simple
 
 submodels:
   submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.enforce
@@ -75,15 +77,9 @@ submodels:
 
 optimization: # This section is needed only if optimization process is run
   design_variables:
-    - name: data:propulsion:he_power_train:propeller:propeller_1:solidity
-      lower: 0.1
-      upper: 0.4
-    - name: data:propulsion:he_power_train:propeller:propeller_1:activity_factor
-      lower: 50
-      upper: 250
-    - name: data:propulsion:he_power_train:propeller:propeller_1:blade_twist
-      lower: 10
-      upper: 35
+    - name: data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split
+      lower: 80.0
+      upper: 95.0
   objective:
-    - name: data:mission:sizing:energy
-      scaler: 1.e-4
+    - name: data:environmental_impact:sizing:emissions
+      scaler: 1.e-5

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
@@ -1,0 +1,89 @@
+title: Sample OAD Process
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/full_sizing_hybrid_in.xml
+output_file: ../results/full_sizing_hybrid_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
+
+model:
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  linear_solver: om.LinearBlockGS()
+  geometry:
+    id: fastga.geometry.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  aerodynamics_lowspeed:
+    id: fastga.aerodynamics.lowspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path : ../workdir
+    compute_slipstream : false
+  aerodynamics_highspeed:
+    id: fastga.aerodynamics.highspeed.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    result_folder_path: ../workdir
+    compute_mach_interpolation: false
+    compute_slipstream: false
+  power_train_sizing:
+    id: fastga_he.power_train.sizing
+    power_train_file_path: ./hybrid_propulsion.yml
+  weight:
+    id: fastga.weight.legacy
+    propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+  performances:
+    id: fastga_he.performances.mission_vector
+    number_of_points_climb: 30
+    number_of_points_cruise: 30
+    number_of_points_descent: 20
+    number_of_points_reserve: 10
+    power_train_file_path: ./hybrid_propulsion.yml
+    out_file: ../results/hybrid_propulsion.csv
+    use_linesearch: False
+    pre_condition_pt: False
+    use_apply_nonlinear: False
+  mtow:
+    id: fastga.loop.mtow
+  hq:
+    tail_sizing:
+      id: fastga.handling_qualities.tail_sizing
+      propulsion_id: fastga.wrapper.propulsion.basicIC_engine
+    static_margin:
+      id: fastga.handling_qualities.static_margin
+  wing_position:
+    id: fastga.loop.wing_position
+  wing_area:
+    id: fastga.loop.wing_area
+#    power_train_file_path: ./fuel_propulsion.yml
+
+submodels:
+  submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.enforce
+  submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null
+  service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
+  service.weight.mass.system.power_system: null
+  service.geometry.nacelle.dimension: null
+  service.geometry.vertical_tail.distance.fd: null
+  service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+
+optimization: # This section is needed only if optimization process is run
+  design_variables:
+    - name: data:propulsion:he_power_train:propeller:propeller_1:solidity
+      lower: 0.1
+      upper: 0.4
+    - name: data:propulsion:he_power_train:propeller:propeller_1:activity_factor
+      lower: 50
+      upper: 250
+    - name: data:propulsion:he_power_train:propeller:propeller_1:blade_twist
+      lower: 10
+      upper: 35
+  objective:
+    - name: data:mission:sizing:energy
+      scaler: 1.e-4

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid.yml
@@ -10,6 +10,10 @@ output_file: ../results/full_sizing_hybrid_out.xml
 # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
 driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
 
+model_options:
+  "*motor_1*":
+    adjust_rpm_rating: True
+
 model:
   nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-8, atol=1, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8)
   linear_solver: om.LinearBlockGS()
@@ -59,6 +63,7 @@ model:
 #    power_train_file_path: ./fuel_propulsion.yml
   environmental_impact:
     id: fastga_he.environmental.energy_simple
+    electricity_mix: france
 
 submodels:
   submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.enforce
@@ -75,12 +80,3 @@ submodels:
   service.geometry.vertical_tail.distance.fd: null
   service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
   submodel.performances.mission_vector.reserve_speed: null
-
-optimization: # This section is needed only if optimization process is run
-  design_variables:
-    - name: data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split
-      lower: 80.0
-      upper: 95.0
-  objective:
-    - name: data:environmental_impact:sizing:emissions
-      scaler: 1.e-5

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -66,6 +66,7 @@ model:
 #    power_train_file_path: ./fuel_propulsion.yml
   environmental_impact:
     id: fastga_he.environmental.energy_simple
+    electricity_mix: france
 
 submodels:
   submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.enforce

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -18,7 +18,7 @@ model_options:
     reference_curve_relative_capacity: [ 1.0, 0.97, 1.0, 0.97, 0.95 ]
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8, stall_limit=5, stall_tol=3e-6)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, atol=1e3, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8, stall_limit=5, stall_tol=3e-6)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy
@@ -81,12 +81,3 @@ submodels:
   service.geometry.nacelle.dimension: null
   service.geometry.vertical_tail.distance.fd: null
   service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
-
-optimization: # This section is needed only if optimization process is run
-  design_variables:
-    - name: data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_share
-      lower: 150.0  # Not worth going below as it is going to be too heavy
-      upper: 195.0  # Not worth going above as it will crash because the electric branch won't receive power
-  objective:
-    - name: data:environmental_impact:sizing:emissions
-      scaler: 1.e-4

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -18,7 +18,7 @@ model_options:
     reference_curve_relative_capacity: [ 1.0, 0.97, 1.0, 0.97, 0.95 ]
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, atol=1e3, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8, stall_limit=5, stall_tol=3e-6)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-8, atol=1, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8, stall_limit=5, stall_tol=3e-6)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -4,14 +4,14 @@ title: Sample OAD Process
 module_folders:
 
 # Input and output files
-input_file: ../results/full_sizing_elec_in_two_motors.xml
-output_file: ../results/full_sizing_elec_out_two_motors.xml
+input_file: ../results/full_sizing_hybrid_in_power_share.xml
+output_file: ../results/full_sizing_hybrid_out_power_share.xml
 
 # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
 driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=50, iprint=2, rtol=1e-5, atol=5e3, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy
@@ -29,7 +29,7 @@ model:
     compute_slipstream: false
   power_train_sizing:
     id: fastga_he.power_train.sizing
-    power_train_file_path: ./electric_propulsion_two_motors.yml
+    power_train_file_path: ./hybrid_propulsion_power_share.yml
   weight:
     id: fastga.weight.legacy
     propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -39,10 +39,10 @@ model:
     number_of_points_cruise: 30
     number_of_points_descent: 20
     number_of_points_reserve: 10
-    power_train_file_path: ./electric_propulsion_two_motors.yml
-    out_file: ../results/electric_propulsion_two_motors.csv
+    power_train_file_path: ./hybrid_propulsion_power_share.yml
+    out_file: ../results/hybrid_propulsion_power_share.csv
     use_linesearch: False
-    pre_condition_pt: False
+    pre_condition_pt: True
     use_apply_nonlinear: False
   mtow:
     id: fastga.loop.mtow
@@ -56,13 +56,17 @@ model:
     id: fastga.loop.wing_position
   wing_area:
     id: fastga.loop.wing_area
+#    power_train_file_path: ./fuel_propulsion.yml
+  environmental_impact:
+    id: fastga_he.environmental.energy_simple
 
 submodels:
+  submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.enforce
   submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
   submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
-  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
   submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
-  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.ensure
   submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
   submodel.propulsion.dc_dc_converter.inductor.inductance: null
   service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
@@ -70,3 +74,12 @@ submodels:
   service.geometry.nacelle.dimension: null
   service.geometry.vertical_tail.distance.fd: null
   service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+
+optimization: # This section is needed only if optimization process is run
+  design_variables:
+    - name: data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_share
+      lower: 150.0
+      upper: 300.0
+  objective:
+    - name: data:environmental_impact:sizing:emissions
+      scaler: 1.e-4

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -81,3 +81,4 @@ submodels:
   service.geometry.nacelle.dimension: null
   service.geometry.vertical_tail.distance.fd: null
   service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+  submodel.performances.mission_vector.reserve_speed: null

--- a/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/full_sizing_hybrid_power_share.yml
@@ -8,10 +8,17 @@ input_file: ../results/full_sizing_hybrid_in_power_share.xml
 output_file: ../results/full_sizing_hybrid_out_power_share.xml
 
 # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
-driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs"])
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA', debug_print=["objs", "desvars"])
+
+model_options:
+  "*":
+    cell_capacity_ref: 2.5
+    cell_weight_ref: 45.0e-3
+    reference_curve_current: [ 500, 5000, 10000, 15000, 20000 ]
+    reference_curve_relative_capacity: [ 1.0, 0.97, 1.0, 0.97, 0.95 ]
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, iprint=2, rtol=1e-5, debug_print=True, reraise_child_analysiserror=True, use_aitken=True, aitken_max_factor=0.8, aitken_min_factor=0.33, aitken_initial_factor=0.8, stall_limit=5, stall_tol=3e-6)
   linear_solver: om.LinearBlockGS()
   geometry:
     id: fastga.geometry.legacy
@@ -66,7 +73,7 @@ submodels:
   submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
   submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
   submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
-  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.ensure
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
   submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
   submodel.propulsion.dc_dc_converter.inductor.inductance: null
   service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
@@ -78,8 +85,8 @@ submodels:
 optimization: # This section is needed only if optimization process is run
   design_variables:
     - name: data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_share
-      lower: 150.0
-      upper: 300.0
+      lower: 150.0  # Not worth going below as it is going to be too heavy
+      upper: 195.0  # Not worth going above as it will crash because the electric branch won't receive power
   objective:
     - name: data:environmental_impact:sizing:emissions
       scaler: 1.e-4

--- a/integration_tests/cirrus_sr22/data/hybrid_propulsion.yml
+++ b/integration_tests/cirrus_sr22/data/hybrid_propulsion.yml
@@ -1,0 +1,102 @@
+title: Powertrain file for the sizing of the Cirrus SR22
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+
+  planetary_gear_1:
+    id: fastga_he.pt_component.planetary_gear
+    position: in_the_front
+    options:
+      gear_mode: percent_split
+
+  ice_1:
+    id: fastga_he.pt_component.internal_combustion_engine
+    position: in_the_front  # "on_the_wing", "in_the_front", "in_the_back"
+
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  fuel_system_1:
+    id: fastga_he.pt_component.fuel_system
+    options:
+      number_of_engines: 1
+      number_of_tanks: 2
+    position: in_the_front  # "in_the_wing", "in_the_front", "in_the_back"
+
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+    position: from_rear_to_front  # "inside_the_wing", "from_rear_to_front", "from_rear_to_wing", "from_front_to_wing", "from_rear_to_nose", "from_front_to_nose", "from_wing_to_nose"
+  dc_bus_2:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_back  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  fuel_tank_1:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+  fuel_tank_2:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+    symmetrical: fuel_tank_1
+
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: in_the_back
+  battery_pack_1:
+    id: fastga_he.pt_component.battery_pack
+    position: underbelly  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+component_connections:
+  - source: propeller_1
+    target: planetary_gear_1
+
+  - source: [planetary_gear_1, 1]
+    target: ice_1
+
+  - source: ice_1
+    target: [fuel_system_1, 1]
+
+  - source: [fuel_system_1, 1]
+    target: fuel_tank_1
+
+  - source: [fuel_system_1, 2]
+    target: fuel_tank_2
+
+  - source: [planetary_gear_1, 2]
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: [dc_bus_1, 1]
+
+  - source: [dc_bus_1, 1]
+    target: harness_1
+
+  - source: harness_1
+    target: [dc_bus_2, 1]
+
+  - source: [dc_bus_2, 1]
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: battery_pack_1
+
+watcher_file_path: ../results/hybrid_propulsion_pt_watcher.csv

--- a/integration_tests/cirrus_sr22/data/hybrid_propulsion_power_share.yml
+++ b/integration_tests/cirrus_sr22/data/hybrid_propulsion_power_share.yml
@@ -1,0 +1,102 @@
+title: Powertrain file for the sizing of the Cirrus SR22
+
+power_train_components:
+  propeller_1:
+    id: fastga_he.pt_component.propeller
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+
+  planetary_gear_1:
+    id: fastga_he.pt_component.planetary_gear
+    position: in_the_front
+    options:
+      gear_mode: power_share
+
+  ice_1:
+    id: fastga_he.pt_component.internal_combustion_engine
+    position: in_the_front  # "on_the_wing", "in_the_front", "in_the_back"
+
+  motor_1:
+    id: fastga_he.pt_component.pmsm
+    position: in_the_nose  # "on_the_wing", "in_the_nose"
+  inverter_1:
+    id: fastga_he.pt_component.inverter
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  fuel_system_1:
+    id: fastga_he.pt_component.fuel_system
+    options:
+      number_of_engines: 1
+      number_of_tanks: 2
+    position: in_the_front  # "in_the_wing", "in_the_front", "in_the_back"
+
+  dc_bus_1:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_front  # "inside_the_wing", "in_the_front", "in_the_back"
+  harness_1:
+    id: fastga_he.pt_component.dc_line
+    position: from_rear_to_front  # "inside_the_wing", "from_rear_to_front", "from_rear_to_wing", "from_front_to_wing", "from_rear_to_nose", "from_front_to_nose", "from_wing_to_nose"
+  dc_bus_2:
+    id: fastga_he.pt_component.dc_bus
+    options:
+      number_of_inputs: 1
+      number_of_outputs: 1
+    position: in_the_back  # "inside_the_wing", "in_the_front", "in_the_back"
+
+  fuel_tank_1:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+  fuel_tank_2:
+    id: fastga_he.pt_component.fuel_tank
+    position: inside_the_wing  # "inside_the_wing", "wing_pod", "in_the_fuselage"
+    symmetrical: fuel_tank_1
+
+  dc_sspc_1:
+    id: fastga_he.pt_component.dc_sspc
+    options:
+      closed_by_default: True
+    position: in_the_back
+  battery_pack_1:
+    id: fastga_he.pt_component.battery_pack
+    position: underbelly  # "inside_the_wing", "wing_pod", "in_the_front", "in_the_back", "underbelly"
+
+component_connections:
+  - source: propeller_1
+    target: planetary_gear_1
+
+  - source: [planetary_gear_1, 1]
+    target: ice_1
+
+  - source: ice_1
+    target: [fuel_system_1, 1]
+
+  - source: [fuel_system_1, 1]
+    target: fuel_tank_1
+
+  - source: [fuel_system_1, 2]
+    target: fuel_tank_2
+
+  - source: [planetary_gear_1, 2]
+    target: motor_1
+
+  - source: motor_1
+    target: inverter_1
+
+  - source: inverter_1
+    target: [dc_bus_1, 1]
+
+  - source: [dc_bus_1, 1]
+    target: harness_1
+
+  - source: harness_1
+    target: [dc_bus_2, 1]
+
+  - source: [dc_bus_2, 1]
+    target: dc_sspc_1
+
+  - source: dc_sspc_1
+    target: battery_pack_1
+
+watcher_file_path: ../results/hybrid_propulsion_pt_watcher_power_share.csv

--- a/integration_tests/cirrus_sr22/data/input_sr22.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22.xml
@@ -234,8 +234,8 @@
           </reserve>
           <climb>
             <climb_rate>
-              <cruise_level units="ft/min">790.0<!--target climb rate at the end of climb--></cruise_level>
-              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+              <cruise_level units="ft/min">922.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
             </climb_rate>
           </climb>
         </main_route>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
@@ -320,8 +320,8 @@
           </reserve>
           <climb>
             <climb_rate>
-              <cruise_level units="ft/min">790.0<!--target climb rate at the end of climb--></cruise_level>
-              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+              <cruise_level units="ft/min">922.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
             </climb_rate>
           </climb>
         </main_route>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
@@ -1,0 +1,445 @@
+<FASTOAD_model>
+  <data>
+    <TLAR>
+      <NPAX_design>2.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
+      <luggage_mass_design units="kg">55.0<!--luggage design mass--></luggage_mass_design>
+      <range units="NM">31.0<!--top-level requirement: design range--></range>
+      <v_approach units="kn">79.0<!--approach speed--></v_approach>
+      <v_cruise units="kn">160.0<!--cruise speed--></v_cruise>
+      <v_max_sl units="kn" is_input="True">186.0<!--maximum speed at sea level--></v_max_sl>
+    </TLAR>
+    <geometry>
+      <flap_type>1.0<!--flap type (0.0 - plain flap, 2.0 - single slotted flap, 3.0 - split flap)--></flap_type>
+      <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <wing_configuration>1.0</wing_configuration>
+      <cabin>
+        <aisle_width units="m">0.0<!--width of aisles--></aisle_width>
+        <luggage>
+          <mass_max units="kg">60.0<!--maximum luggage mass--></mass_max>
+        </luggage>
+        <seats>
+          <passenger>
+            <NPAX_max>2.0<!--maximum number of passengers in the aircraft--></NPAX_max>
+            <count_by_row>3.0<!--number of passenger seats per row--></count_by_row>
+            <length units="m">1.1<!--passenger seats length--></length>
+            <width units="m">0.4<!--width of passenger seats--></width>
+          </passenger>
+          <pilot>
+            <length units="m">1.05<!--pilot seats length--></length>
+            <width units="m">0.565<!--width of pilot seats--></width>
+          </pilot>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio>0.25<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio>0.53<!--ratio (width of flaps)/(total span)--></span_ratio>
+      </flap>
+      <horizontal_tail>
+        <area units="m**2">2.75<!--horizontal tail area--></area>
+        <aspect_ratio is_input="False">5.47<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <elevator_chord_ratio>0.3<!--elevator chord ratio--></elevator_chord_ratio>
+        <sweep_25 units="deg">4.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio>0.613<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">3.91<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </horizontal_tail>
+      <landing_gear>
+        <type>0.0<!--0=non-retractable / 1=retractable--></type>
+      </landing_gear>
+      <propeller>
+        <depth units="m">0.3<!--depth of the propeller--></depth>
+        <diameter units="m">1.98<!--propeller diameter--></diameter>
+      </propeller>
+      <vertical_tail>
+        <area units="m**2">1.51<!--vertical tail area--></area>
+        <aspect_ratio>2.0<!--aspect ratio of vertical tail--></aspect_ratio>
+        <sweep_25 units="deg">10.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio>0.502<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of vertical tail--></thickness_ratio>
+        <rudder>
+          <chord_ratio>0.33<!--flap rudder as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">20.0<!--rudder maximum deflection--></max_deflection>
+        </rudder>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">4.41<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </vertical_tail>
+      <wing>
+        <area units="m**2">13.46<!--wing reference area--></area>
+        <aspect_ratio>10.12<!--wing aspect ratio--></aspect_ratio>
+        <dihedral units="deg">5.0</dihedral>
+        <twist units="deg">0.0</twist>
+        <sweep_25 units="deg">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <taper_ratio>0.5<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio>0.12<!--mean thickness ratio of wing--></thickness_ratio>
+        <aileron>
+          <chord_ratio>0.25<!--aileron chord as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">30.0</max_deflection>
+          <span_ratio>0.24</span_ratio>
+        </aileron>
+        <kink>
+          <span_ratio>0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+        </kink>
+        <MAC>
+          <at25percent>
+            <x units="m">2.65<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
+          </at25percent>
+        </MAC>
+      </wing>
+      <propulsion>
+        <engine>
+          <count>1.0<!--number of engines--></count>
+          <layout>3.0<!--position of engines (1=under the wing / 2=rear fuselage / 3=nose)--></layout>
+          <y_ratio>0.0<!--engine position with respect to total span--></y_ratio>
+        </engine>
+        <nacelle>
+          <height units="m" is_input="False">0.7546659597502833<!--height of the nacelle--></height>
+          <length units="m" is_input="False">1.148849535217935<!--length of the nacelle--></length>
+          <master_cross_section units="m**2" is_input="False">0.8492852704999014</master_cross_section>
+          <wet_area units="m**2" is_input="False">4.3197777006580775<!--nacelle wet area--></wet_area>
+          <width units="m" is_input="False">1.1253790627855103<!--width of the nacelle--></width>
+        </nacelle>
+      </propulsion>
+    </geometry>
+    <propulsion>
+      <fuel_type>1.0<!--engine fuel type (1.0 - gasoline, 2.0 - gasoil)--></fuel_type>
+      <max_rpm units="min**-1">2700.0<!--maximum number of rotation per minute on the engine--></max_rpm>
+      <IC_engine>
+        <max_power units="W">231000.0<!--maximum power of the engine--></max_power>
+        <strokes_nb>4.0<!--number of strokes on the engine--></strokes_nb>
+      </IC_engine>
+      <he_power_train>
+        <thrust_distribution>1.0</thrust_distribution>
+        <propeller>
+          <propeller_1>
+            <activity_factor>128.6<!--Activity factor of the propeller--></activity_factor>
+            <blade_twist units="deg">17.8<!--Twist between the propeller blade root and tip--></blade_twist>
+            <depth_to_diameter_ratio>0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="m">1.98<!--Diameter of the propeller--></diameter>
+            <installation_angle units="deg">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
+            <material>0.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades>3.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_mission units="1/min">2500.0</rpm_mission>
+            <solidity>0.13517604<!--Solidity of the propeller--></solidity>
+          </propeller_1>
+        </propeller>
+        <DC_SSPC>
+          <dc_sspc_1>
+            <CG>
+              <y_ratio>0.4</y_ratio>
+            </CG>
+          </dc_sspc_1>
+          <dc_sspc_2>
+            <CG>
+              <y_ratio>0.4</y_ratio>
+            </CG>
+          </dc_sspc_2>
+        </DC_SSPC>
+        <DC_cable_harness>
+          <harness_1>
+            <cable_temperature_mission units="degK">303.15</cable_temperature_mission>
+          </harness_1>
+        </DC_cable_harness>
+        <DC_splitter>
+          <dc_splitter_1>
+            <power_split units="percent">50.0</power_split>
+          </dc_splitter_1>
+        </DC_splitter>
+        <PMSM>
+          <motor_1>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">3250.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">830.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_1>
+        </PMSM>
+        <inverter>
+          <inverter_1>
+            <efficiency_mission>0.98</efficiency_mission>
+            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_1>
+        </inverter>
+        <battery_pack>
+          <battery_pack_1>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_1>
+          <battery_pack_2>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_2>
+        </battery_pack>
+      </he_power_train>
+    </propulsion>
+    <aerodynamics>
+      <propeller>
+        <mach is_input="True">0.0<!--mach number used to compute the polar of the airfoil used in the propeller computation--></mach>
+        <reynolds is_input="True">1000000.0<!--reynolds number used to compute the polar of the airfoil used in the propeller computation--></reynolds>
+        <cruise_level>
+          <altitude units="m" is_input="False">2438.4<!--altitude at which the cruise level propeller efficiency map was computed--></altitude>
+          <efficiency is_input="False">[[0.08530005486124256, 0.16829301352015982, 0.19729632102474817, 0.19948091923407776, 0.1919462541607033, 0.18151990502361054, 0.17071828377276843, 0.16055835068023994, 0.1514977491952318, 0.14283249726987826, 0.13461462171811225, 0.12709638574602894, 0.12003000411430331, 0.11350478154756086, 0.10796382230441834, 0.10282339988923522, 0.097776536438269, 0.09183076775470722, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149], [0.21898409717137646, 0.40860062791900587, 0.46627979554573395, 0.47353799840204236, 0.46197538443722513, 0.44395677687579493, 0.4240786363668649, 0.4046711622026329, 0.38679220698271255, 0.3699759641037544, 0.35298941135115025, 0.33717552270609685, 0.3222396600355954, 0.30768374985559105, 0.2941909091689512, 0.2826241789156212, 0.2717196412424635, 0.2611171470407305, 0.24968947461043978, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758], [0.3221821674387253, 0.54705852614785, 0.6094073636176869, 0.6207928152748975, 0.6125811135953867, 0.5963887835661168, 0.5770310730547497, 0.5569800199499474, 0.5378755337393591, 0.5204922804408615, 0.5019162003192688, 0.4838034583336272, 0.46668566213460727, 0.4502992934226298, 0.4333917579715272, 0.41823641941567186, 0.40496247713128364, 0.39215375852322937, 0.3797062616388516, 0.3667018100857163, 0.34991710488525835, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749], [0.3840847534404945, 0.6163723279469772, 0.6816313277992596, 0.6977179055990025, 0.6946876738814904, 0.6832304234487679, 0.6678054537563645, 0.6507730155955819, 0.633471466687619, 0.6180174682694553, 0.6014636738692486, 0.5840687173943357, 0.5673989254129931, 0.5512673208418547, 0.5354907126735293, 0.5189214467882629, 0.5043710925937906, 0.4912194090519666, 0.47837308094399594, 0.46578383617303787, 0.4528986393692126, 0.4367931098904753, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894], [0.4162206845504372, 0.6447180480543131, 0.7135170076505943, 0.7355876092833685, 0.7383238439925945, 0.7321561969119317, 0.7214475048364544, 0.7084832815542957, 0.6944863326765549, 0.6815148523448301, 0.6677208605045626, 0.6526082187226498, 0.6375655318133149, 0.6227682413928755, 0.6084197705521291, 0.5935910882220362, 0.5788231168982322, 0.565638863525112, 0.5532535287577882, 0.5411682790067882, 0.5292177821320938, 0.516983782697819, 0.5023188236684182, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427], [0.4069859818949012, 0.6484424054652869, 0.7229776812708956, 0.751460555371571, 0.759973043525158, 0.7591136433974462, 0.7529751346725001, 0.7440554187834634, 0.7336824494099241, 0.7234821449485286, 0.7122773688030222, 0.6997743309620104, 0.6869201554758978, 0.6739700927993334, 0.6612173003670883, 0.6483048784607617, 0.6349219162681938, 0.622233350869981, 0.6103925901336436, 0.5990528623199329, 0.5879646260227047, 0.5769442973750399, 0.5656497083168188, 0.5525081844483241, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039], [0.3947191962156007, 0.6365944318761548, 0.7202659706653445, 0.7548847315587227, 0.7689894907419799, 0.7730034616768446, 0.771170566163189, 0.7659912585066122, 0.7590769282499837, 0.7515138373399238, 0.74276068665281, 0.7326710070730431, 0.7220380965921961, 0.7110340456352593, 0.699990715817601, 0.6888711738011027, 0.6772095445285499, 0.6656676309390444, 0.6546833775008339, 0.6441323728290667, 0.6338467617699817, 0.6237619702210907, 0.6137156549682009, 0.6034537111765756, 0.5918190142266423, 0.575022851066347, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107], [0.37064153384005905, 0.6215881980042637, 0.711150239324778, 0.7512916886191463, 0.7706039901994188, 0.7789740112273803, 0.7810703885488236, 0.7793150493167846, 0.7754764321313032, 0.7703918081206474, 0.7639289870626179, 0.7560087732505143, 0.7473820938032627, 0.738282542440783, 0.7289114612304615, 0.7193990282090695, 0.7094941378115631, 0.6992647342068092, 0.6893388780495783, 0.6796975040873476, 0.6703012018911672, 0.6610268470504826, 0.6518719626451218, 0.6427420288461364, 0.6334653452524432, 0.6232275001609469, 0.6103811245963924, 0.6036861163374001, 0.6036861163374001, 0.6036861163374001], [0.3549459268348402, 0.6019916951199231, 0.6977553222217443, 0.7439880801720442, 0.7679914676049849, 0.7802746527801914, 0.7857390157782621, 0.7870148735983472, 0.7859366670138092, 0.7831059571064102, 0.7786884236334871, 0.7727834250453334, 0.7659858818955847, 0.7585897018801246, 0.7507943921728022, 0.742749259157464, 0.7343721564942727, 0.7255565313751866, 0.7167064968026865, 0.7080570299514463, 0.6995321238438824, 0.691106653633415, 0.6827668089780798, 0.6744751776147121, 0.6661856211066182, 0.6578098842165556, 0.6487977889029929, 0.6382216448259804, 0.6280241546079525, 0.6280241546079525], [0.3240202709619619, 0.5805271356146239, 0.6832491490506619, 0.734743399347032, 0.7629922010757247, 0.7788244989155665, 0.7872722146120348, 0.79119030253486, 0.7924152171565334, 0.7916024986382685, 0.7890316189418384, 0.7849491522890222, 0.779782668763414, 0.7739140769019306, 0.7675653509203515, 0.7608471433395458, 0.7537952117070004, 0.7463499252428681, 0.738603278788942, 0.7308702107417007, 0.7232405630129382, 0.7156525895027663, 0.7080657977241661, 0.7005420445821557, 0.6930230902659031, 0.6854986187191139, 0.6778985410310467, 0.6699611850296374, 0.6610305809456005, 0.6476421164613491]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at cruise level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at cruise level are computed--></speed>
+          <thrust units="N" is_input="False">[163.447801591381, 456.8832398290857, 750.3186780667904, 1043.7541163044953, 1337.1895545421999, 1630.6249927799045, 1924.0604310176093, 2217.495869255314, 2510.9313074930187, 2804.3667457307233, 3097.802183968428, 3391.237622206133, 3684.6730604438376, 3978.108498681542, 4271.543936919247, 4564.979375156951, 4858.414813394656, 5151.8502516323615, 5445.285689870066, 5738.721128107771, 6032.156566345475, 6325.59200458318, 6619.027442820885, 6912.462881058589, 7205.898319296294, 7499.333757533999, 7792.769195771703, 8086.204634009408, 8379.640072247113, 8673.075510484818]<!--thrust produced by the propeller at cruise level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[5166.687446702883, 5683.084379455381, 6104.941620936745, 6472.966495514782, 6819.855775185387, 7161.545168399918, 7508.616995426542, 7868.808840383192, 8254.67947404465, 8673.075510484818]<!--maximum thrust output of the propeller at cruise level for varying velocities--></thrust_limit>
+        </cruise_level>
+        <sea_level>
+          <efficiency is_input="False">[[0.08559524652103005, 0.16746079374777373, 0.19700334637165667, 0.1997708841011615, 0.19266563931119182, 0.18249945813876728, 0.17187221081889678, 0.16179598598205108, 0.15279191802180817, 0.14420689755285862, 0.1359887975944682, 0.1284682176722167, 0.12142752525910311, 0.11482058873387413, 0.10922456578374536, 0.10409393339502468, 0.09909897012707508, 0.09354611420669316, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878], [0.21946683955857027, 0.4070653813646662, 0.4656512860894166, 0.4738513549980477, 0.4631998668180335, 0.4457605310821373, 0.42627268655372336, 0.40711600630357425, 0.3893980713967947, 0.3728107754376203, 0.35593852900489553, 0.3401588885590199, 0.32527598717498685, 0.31080232316423495, 0.29716167335245053, 0.28550448609430107, 0.27462422109232054, 0.2641024291551355, 0.2530944970363329, 0.23751757158728953, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416], [0.32295240661343527, 0.545587317977352, 0.6086955644209024, 0.621073801322977, 0.6137032720618116, 0.5981852023617394, 0.5793226760693, 0.5596245367201715, 0.5407400664411743, 0.5236415832816252, 0.5053182919871878, 0.487307499402436, 0.4702535847438607, 0.4540024280022737, 0.43725452406498266, 0.42187298218113917, 0.4085683837175746, 0.3958226535019926, 0.3834550018470688, 0.37083713946439095, 0.35511571212452414, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085], [0.38485662650771013, 0.6149284281262366, 0.680928584926233, 0.6979238400830844, 0.6956546136037444, 0.6848044854741254, 0.6698590343459225, 0.6532081849326775, 0.6361431536072055, 0.6210239535985712, 0.6047878596596149, 0.5875558772862273, 0.5710068630367056, 0.5549738893472026, 0.5393703187482276, 0.5229040328056744, 0.5082299514539513, 0.4950863361961832, 0.4823301053823931, 0.4698387692922264, 0.4572267778273543, 0.4419975160654984, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031], [0.41646514016979747, 0.6434352427283466, 0.7128217474307318, 0.7356950909690921, 0.7390073188405037, 0.7334254787546669, 0.7231912616629405, 0.7106049759583282, 0.6969631753296891, 0.6842245814347332, 0.6707300634702648, 0.6558518245385779, 0.6409675406536163, 0.6263010174428982, 0.6120891019859229, 0.5974565305343131, 0.5826787040317936, 0.5694960837894123, 0.5571698893121968, 0.5451634650356759, 0.5333257323912791, 0.5212968187573547, 0.5073397562276435, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998], [0.409455378135157, 0.6473345846622222, 0.7223147863600431, 0.7514764752690146, 0.7605036797131038, 0.7601721845258685, 0.7544204997326877, 0.7458851729668731, 0.7358617896966939, 0.7259313436535808, 0.7149986021712363, 0.7026942311022902, 0.6900289608728961, 0.6772297533647824, 0.6646183122217576, 0.6518790959788052, 0.6385848136034126, 0.6259679819780883, 0.6141778123645895, 0.6029121762392661, 0.5919030780374738, 0.5809818952622033, 0.5698720398613432, 0.557217324025475, 0.5372944491852183, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414], [0.3953312638004441, 0.6358115370524278, 0.7196996332074858, 0.7548432086869586, 0.7694092269011428, 0.773832881644416, 0.7724242657122274, 0.7675665995019243, 0.7610074890956313, 0.7537129129619586, 0.7451907098452001, 0.7353012807651571, 0.7248475866981763, 0.714015272638944, 0.7031205982212984, 0.692145975087162, 0.6806184723781162, 0.6691779531618413, 0.658279803844729, 0.6478016191218834, 0.637599039386411, 0.6275947375293485, 0.6176408964767897, 0.6075142201040424, 0.5962206004520426, 0.5813318776712864, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875], [0.37502214790548005, 0.621513702458121, 0.7106598336732024, 0.7512486934842537, 0.7709687399998211, 0.7797129768048593, 0.7821466237893939, 0.7807195992387596, 0.777239236257852, 0.7724066683263304, 0.7661288703458095, 0.7584143086559684, 0.7499418418991161, 0.7410174056290642, 0.7318034765974706, 0.7224233087124184, 0.7126289298037244, 0.7025142675967138, 0.6927099445099428, 0.6831584952387556, 0.6738623108724029, 0.6646719000901224, 0.6556001557389005, 0.6465481583464296, 0.6373780578932061, 0.6273363973051153, 0.6150016987364886, 0.6057495835080302, 0.6057495835080302, 0.6057495835080302], [0.35508508960321633, 0.601405382049293, 0.6973966914478564, 0.7439989072630241, 0.7683660336108185, 0.7809881021710351, 0.7867626680387921, 0.7883464328502263, 0.7875783300712109, 0.7850084714489851, 0.7807432930120342, 0.7750217914073025, 0.7683659693251536, 0.7611277284841014, 0.7534858390350037, 0.7455796856748332, 0.7373097504283624, 0.728602057524929, 0.7198716458340264, 0.7113281930517014, 0.702903445541824, 0.6945660765205901, 0.6863239840190664, 0.6781044656160994, 0.6698991214263045, 0.6615946458117216, 0.6526938773741703, 0.6422847359663604, 0.6303181609714937, 0.6303181609714937], [0.32688741261648224, 0.5804727423083644, 0.6831129180397443, 0.7348673233187948, 0.7634321345443952, 0.7795721244454902, 0.7882882658060564, 0.7925302028986236, 0.794015043273824, 0.7934572457863657, 0.7909915389033304, 0.7870631908251293, 0.7820364066960803, 0.776325135869199, 0.770123944795257, 0.7635379460083411, 0.756583439306165, 0.7492190954094681, 0.7415941988825705, 0.7339711052029734, 0.7264464102959793, 0.7189606778007763, 0.7114646261817927, 0.7040172063029317, 0.6965813695746137, 0.6891321045957475, 0.6815952960622204, 0.67369851983467, 0.6648170015283738, 0.6502311380843497]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at sea level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at sea level are computed--></speed>
+          <thrust units="N" is_input="False">[208.48223431412015, 575.2513628160312, 942.0204913179423, 1308.7896198198534, 1675.5587483217646, 2042.3278768236758, 2409.0970053255865, 2775.866133827498, 3142.6352623294088, 3509.4043908313197, 3876.173519333231, 4242.942647835142, 4609.711776337053, 4976.480904838964, 5343.250033340876, 5710.019161842787, 6076.788290344698, 6443.557418846609, 6810.32654734852, 7177.095675850432, 7543.864804352343, 7910.6339328542535, 8277.403061356164, 8644.172189858076, 9010.941318359986, 9377.710446861898, 9744.479575363808, 10111.24870386572, 10478.017832367632, 10844.786960869542]<!--thrust produced by the propeller at sea level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[6533.840174009261, 7181.649624427429, 7704.744804457652, 8163.379307607336, 8591.84017293703, 9012.766951506735, 9435.643628430062, 9874.443915635982, 10339.44635971018, 10844.786960869542]<!--maximum thrust output of the propeller at sea level for varying velocities--></thrust_limit>
+        </sea_level>
+      </propeller>
+    </aerodynamics>
+    <handling_qualities>
+      <static_margin>
+        <target>0.15<!--static margin we want to achieve--></target>
+      </static_margin>
+    </handling_qualities>
+    <mission>
+      <sizing>
+        <initial_climb>
+          <energy units="W*h">0.0</energy>
+          <fuel units="kg">0.08855397685162596</fuel>
+        </initial_climb>
+        <landing>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during landing--></elevator_angle>
+          <flap_angle units="deg">30.0<!--position of the flaps during landing--></flap_angle>
+          <target_sideslip units="deg">15.0</target_sideslip>
+        </landing>
+        <takeoff>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during takeoff--></elevator_angle>
+          <energy units="W*h">0.0</energy>
+          <flap_angle units="deg">10.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
+          <fuel units="kg">0.4560783599663149</fuel>
+          <thrust_rate>1.0<!--thrust rate during takeoff phase--></thrust_rate>
+        </takeoff>
+        <taxi_in>
+          <duration units="s">300.0<!--duration of taxi-in phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-in phase in sizing mission--></speed>
+        </taxi_in>
+        <taxi_out>
+          <duration units="s">300.0<!--duration of taxi-out phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-out phase in sizing mission--></speed>
+        </taxi_out>
+        <cs23>
+          <characteristic_speed>
+            <vd units="kn">202.6<!--limit speed--></vd>
+          </characteristic_speed>
+          <sizing_factor>
+            <ultimate_aircraft>5.7<!--ultimate load factor that the aircraft will experience (default value is 5.7)--></ultimate_aircraft>
+          </sizing_factor>
+        </cs23>
+        <main_route>
+          <cruise>
+            <altitude units="ft">2000.0<!--altitude during cruise phase in sizing mission--></altitude>
+          </cruise>
+          <descent>
+            <descent_rate units="ft/min">-500.0<!--target descent rate for the aircraft--></descent_rate>
+          </descent>
+          <reserve>
+            <altitude units="ft">2000.0<!--altitude during cruise phase in sizing mission--></altitude>
+            <duration units="min">45.0<!--duration of the reserve segment--></duration>
+          </reserve>
+          <climb>
+            <climb_rate>
+              <cruise_level units="ft/min">1279.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
+            </climb_rate>
+          </climb>
+        </main_route>
+      </sizing>
+    </mission>
+    <weight>
+      <airframe>
+        <fuselage>
+          <k_factor>1.0<!--proportional corrective factor for fuselage mass--></k_factor>
+        </fuselage>
+        <horizontal_tail>
+          <k_factor>1.0<!--proportional corrective factor for horizontal tail mass--></k_factor>
+        </horizontal_tail>
+        <paint>
+          <mass units="lbm">1.0<!--Mass of the airframe_inp_data:weight:airframe:paint:mass--></mass>
+        </paint>
+        <vertical_tail>
+          <k_factor>1.0<!--proportional corrective factor for vertical tail mass--></k_factor>
+        </vertical_tail>
+        <wing>
+          <k_factor>0.9<!--proportional corrective factor for wing mass--></k_factor>
+        </wing>
+      </airframe>
+      <propulsion>
+        <engine>
+          <mass units="lbm">731.6708415039819<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
+        </engine>
+        <fuel_lines>
+          <mass units="lbm">71.48274780115939<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
+        </fuel_lines>
+        <unusable_fuel>
+          <mass units="lbm">0.0<!--total unusable fuel mass--></mass>
+        </unusable_fuel>
+      </propulsion>
+      <systems>
+        <power>
+          <electric_systems>
+            <mass units="lbm">189.12923759516593<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="lbm">25.5648480458697<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+  </data>
+  <settings>
+    <handling_qualities>
+      <rudder>
+        <safety_margin>0.2<!--Ratio of the total rudder deflection not used in the computation of the VT area to leave a safety margin--></safety_margin>
+      </rudder>
+    </handling_qualities>
+    <propulsion>
+      <IC_engine>
+        <k_factor_sfc>1.0<!--k_factor that can be used to adjust the consumption on engine level to the aircraft level--></k_factor_sfc>
+      </IC_engine>
+      <he_power_train>
+        <ICE>
+          <ice_1>
+            <cg_in_nacelle>0.9<!--Location of the engine CG in the nacelle, in percent of the nacelle length--></cg_in_nacelle>
+            <k_sfc>1.0<!--K-factor to adjust the sfc of the ICE--></k_sfc>
+          </ice_1>
+        </ICE>
+      </he_power_train>
+    </propulsion>
+    <weight>
+      <aircraft>
+        <CG>
+          <range>0.217<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg">80.0<!--design payload mass carried by passenger--></design_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <landing_gear>
+          <front>
+            <weight_ratio>0.13<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+          </front>
+        </landing_gear>
+      </airframe>
+      <propulsion>
+        <tank>
+          <CG>
+            <from_wingMAC25>0.25<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
+          </CG>
+        </tank>
+      </propulsion>
+    </weight>
+    <mission>
+      <sizing>
+        <main_route>
+          <reserve>
+            <speed>
+              <k_factor is_input="True">2.2<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+            </speed>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+  </settings>
+  <convergence>
+    <propulsion>
+      <he_power_train>
+        <battery_pack>
+          <battery_pack_1>
+            <number_modules_limiter is_input="True">0.5<!--Convergence parameter used the reduction of the amount of cell from one loop to the other--></number_modules_limiter>
+          </battery_pack_1>
+          <battery_pack_2>
+            <number_modules_limiter is_input="True">0.5<!--Convergence parameter used the reduction of the amount of cell from one loop to the other--></number_modules_limiter>
+          </battery_pack_2>
+        </battery_pack>
+        <propeller>
+          <propeller_1>
+            <min_power units="kW" is_input="True">5.0<!--Convergence parameter used to aid convergence since, if power is too low in the network, the code will have trouble converging--></min_power>
+          </propeller_1>
+        </propeller>
+      </he_power_train>
+    </propulsion>
+  </convergence>
+</FASTOAD_model>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric.xml
@@ -3,7 +3,7 @@
     <TLAR>
       <NPAX_design>2.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
       <luggage_mass_design units="kg">55.0<!--luggage design mass--></luggage_mass_design>
-      <range units="NM">31.0<!--top-level requirement: design range--></range>
+      <range units="NM">100.0<!--top-level requirement: design range--></range>
       <v_approach units="kn">79.0<!--approach speed--></v_approach>
       <v_cruise units="kn">160.0<!--cruise speed--></v_cruise>
       <v_max_sl units="kn" is_input="True">186.0<!--maximum speed at sea level--></v_max_sl>
@@ -277,7 +277,7 @@
       <sizing>
         <initial_climb>
           <energy units="W*h">0.0</energy>
-          <fuel units="kg">0.08855397685162596</fuel>
+          <fuel units="kg">0.0</fuel>
         </initial_climb>
         <landing>
           <elevator_angle units="deg">-25.0<!--position of the elevator during landing--></elevator_angle>
@@ -288,7 +288,7 @@
           <elevator_angle units="deg">-25.0<!--position of the elevator during takeoff--></elevator_angle>
           <energy units="W*h">0.0</energy>
           <flap_angle units="deg">10.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
-          <fuel units="kg">0.4560783599663149</fuel>
+          <fuel units="kg">0.0</fuel>
           <thrust_rate>1.0<!--thrust rate during takeoff phase--></thrust_rate>
         </takeoff>
         <taxi_in>
@@ -309,19 +309,19 @@
         </cs23>
         <main_route>
           <cruise>
-            <altitude units="ft">2000.0<!--altitude during cruise phase in sizing mission--></altitude>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
           </cruise>
           <descent>
             <descent_rate units="ft/min">-500.0<!--target descent rate for the aircraft--></descent_rate>
           </descent>
           <reserve>
-            <altitude units="ft">2000.0<!--altitude during cruise phase in sizing mission--></altitude>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
             <duration units="min">45.0<!--duration of the reserve segment--></duration>
           </reserve>
           <climb>
             <climb_rate>
-              <cruise_level units="ft/min">1279.0<!--target climb rate at the end of climb--></cruise_level>
-              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
+              <cruise_level units="ft/min">790.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
             </climb_rate>
           </climb>
         </main_route>
@@ -416,7 +416,7 @@
         <main_route>
           <reserve>
             <speed>
-              <k_factor is_input="True">2.2<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+              <k_factor is_input="True">1.3<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
             </speed>
           </reserve>
         </main_route>
@@ -426,14 +426,6 @@
   <convergence>
     <propulsion>
       <he_power_train>
-        <battery_pack>
-          <battery_pack_1>
-            <number_modules_limiter is_input="True">0.5<!--Convergence parameter used the reduction of the amount of cell from one loop to the other--></number_modules_limiter>
-          </battery_pack_1>
-          <battery_pack_2>
-            <number_modules_limiter is_input="True">0.5<!--Convergence parameter used the reduction of the amount of cell from one loop to the other--></number_modules_limiter>
-          </battery_pack_2>
-        </battery_pack>
         <propeller>
           <propeller_1>
             <min_power units="kW" is_input="True">5.0<!--Convergence parameter used to aid convergence since, if power is too low in the network, the code will have trouble converging--></min_power>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
@@ -166,13 +166,15 @@
         <PMSM>
           <motor_1>
             <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
-            <rpm_rating units="1/min" is_input="True">3250.0<!--Max voltage of the motor--></rpm_rating>
+            <rpm_rating units="1/min" is_input="True">4000.0<!--Max voltage of the motor--></rpm_rating>
             <voltage_caliber units="V" is_input="True">830.0<!--Max voltage of the motor--></voltage_caliber>
+            <torque_rating units="N*m" is_input="True">425.0<!--Max voltage of the motor--></torque_rating>
           </motor_1>
           <motor_2>
             <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
-            <rpm_rating units="1/min" is_input="True">3250.0<!--Max voltage of the motor--></rpm_rating>
+            <rpm_rating units="1/min" is_input="True">4000.0<!--Max voltage of the motor--></rpm_rating>
             <voltage_caliber units="V" is_input="True">830.0<!--Max voltage of the motor--></voltage_caliber>
+            <torque_rating units="N*m" is_input="True">425.0<!--Max voltage of the motor--></torque_rating>
           </motor_2>
         </PMSM>
         <inverter>
@@ -295,7 +297,7 @@
             <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
             <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
             <module>
-              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+              <number_cells is_input="True">120.0<!--Number of cells in series inside one battery module--></number_cells>
             </module>
             <CG>
               <y_ratio>0.5</y_ratio>
@@ -308,7 +310,7 @@
             <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
             <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
             <module>
-              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+              <number_cells is_input="True">120.0<!--Number of cells in series inside one battery module--></number_cells>
             </module>
             <CG>
               <y_ratio>0.5</y_ratio>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
@@ -1,0 +1,505 @@
+<FASTOAD_model>
+  <data>
+    <TLAR>
+      <NPAX_design>2.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
+      <luggage_mass_design units="kg">55.0<!--luggage design mass--></luggage_mass_design>
+      <range units="NM">100.0<!--top-level requirement: design range--></range>
+      <v_approach units="kn">79.0<!--approach speed--></v_approach>
+      <v_cruise units="kn">160.0<!--cruise speed--></v_cruise>
+      <v_max_sl units="kn" is_input="True">186.0<!--maximum speed at sea level--></v_max_sl>
+    </TLAR>
+    <geometry>
+      <flap_type>1.0<!--flap type (0.0 - plain flap, 2.0 - single slotted flap, 3.0 - split flap)--></flap_type>
+      <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <wing_configuration>1.0</wing_configuration>
+      <cabin>
+        <aisle_width units="m">0.0<!--width of aisles--></aisle_width>
+        <luggage>
+          <mass_max units="kg">60.0<!--maximum luggage mass--></mass_max>
+        </luggage>
+        <seats>
+          <passenger>
+            <NPAX_max>2.0<!--maximum number of passengers in the aircraft--></NPAX_max>
+            <count_by_row>3.0<!--number of passenger seats per row--></count_by_row>
+            <length units="m">1.1<!--passenger seats length--></length>
+            <width units="m">0.4<!--width of passenger seats--></width>
+          </passenger>
+          <pilot>
+            <length units="m">1.05<!--pilot seats length--></length>
+            <width units="m">0.565<!--width of pilot seats--></width>
+          </pilot>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio>0.25<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio>0.53<!--ratio (width of flaps)/(total span)--></span_ratio>
+      </flap>
+      <horizontal_tail>
+        <area units="m**2">2.75<!--horizontal tail area--></area>
+        <aspect_ratio is_input="False">5.47<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <elevator_chord_ratio>0.3<!--elevator chord ratio--></elevator_chord_ratio>
+        <sweep_25 units="deg">4.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio>0.613<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">3.91<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </horizontal_tail>
+      <landing_gear>
+        <type>0.0<!--0=non-retractable / 1=retractable--></type>
+      </landing_gear>
+      <propeller>
+        <depth units="m">0.3<!--depth of the propeller--></depth>
+        <diameter units="m">1.98<!--propeller diameter--></diameter>
+      </propeller>
+      <vertical_tail>
+        <area units="m**2">1.51<!--vertical tail area--></area>
+        <aspect_ratio>2.0<!--aspect ratio of vertical tail--></aspect_ratio>
+        <sweep_25 units="deg">10.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio>0.502<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of vertical tail--></thickness_ratio>
+        <rudder>
+          <chord_ratio>0.33<!--flap rudder as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">20.0<!--rudder maximum deflection--></max_deflection>
+        </rudder>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">4.41<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </vertical_tail>
+      <wing>
+        <area units="m**2">13.46<!--wing reference area--></area>
+        <aspect_ratio>10.12<!--wing aspect ratio--></aspect_ratio>
+        <dihedral units="deg">5.0</dihedral>
+        <twist units="deg">0.0</twist>
+        <sweep_25 units="deg">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <taper_ratio>0.5<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio>0.12<!--mean thickness ratio of wing--></thickness_ratio>
+        <aileron>
+          <chord_ratio>0.25<!--aileron chord as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">30.0</max_deflection>
+          <span_ratio>0.24</span_ratio>
+        </aileron>
+        <kink>
+          <span_ratio>0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+        </kink>
+        <MAC>
+          <at25percent>
+            <x units="m">2.65<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
+          </at25percent>
+        </MAC>
+      </wing>
+      <propulsion>
+        <engine>
+          <count>1.0<!--number of engines--></count>
+          <layout>3.0<!--position of engines (1=under the wing / 2=rear fuselage / 3=nose)--></layout>
+          <y_ratio>0.0<!--engine position with respect to total span--></y_ratio>
+        </engine>
+        <nacelle>
+          <height units="m" is_input="False">0.7546659597502833<!--height of the nacelle--></height>
+          <length units="m" is_input="False">1.148849535217935<!--length of the nacelle--></length>
+          <master_cross_section units="m**2" is_input="False">0.8492852704999014</master_cross_section>
+          <wet_area units="m**2" is_input="False">4.3197777006580775<!--nacelle wet area--></wet_area>
+          <width units="m" is_input="False">1.1253790627855103<!--width of the nacelle--></width>
+        </nacelle>
+      </propulsion>
+    </geometry>
+    <propulsion>
+      <fuel_type>1.0<!--engine fuel type (1.0 - gasoline, 2.0 - gasoil)--></fuel_type>
+      <max_rpm units="min**-1">2700.0<!--maximum number of rotation per minute on the engine--></max_rpm>
+      <IC_engine>
+        <max_power units="W">231000.0<!--maximum power of the engine--></max_power>
+        <strokes_nb>4.0<!--number of strokes on the engine--></strokes_nb>
+      </IC_engine>
+      <he_power_train>
+        <thrust_distribution>1.0</thrust_distribution>
+        <propeller>
+          <propeller_1>
+            <activity_factor>128.6<!--Activity factor of the propeller--></activity_factor>
+            <blade_twist units="deg">17.8<!--Twist between the propeller blade root and tip--></blade_twist>
+            <depth_to_diameter_ratio>0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="m">1.98<!--Diameter of the propeller--></diameter>
+            <installation_angle units="deg">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
+            <material>0.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades>3.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_mission units="1/min">2500.0</rpm_mission>
+            <solidity>0.13517604<!--Solidity of the propeller--></solidity>
+          </propeller_1>
+        </propeller>
+        <DC_SSPC>
+          <dc_sspc_1>
+            <CG>
+              <y_ratio>0.4</y_ratio>
+            </CG>
+          </dc_sspc_1>
+          <dc_sspc_2>
+            <CG>
+              <y_ratio>0.4</y_ratio>
+            </CG>
+          </dc_sspc_2>
+        </DC_SSPC>
+        <DC_cable_harness>
+          <harness_1>
+            <cable_temperature_mission units="degK">303.15</cable_temperature_mission>
+          </harness_1>
+        </DC_cable_harness>
+        <DC_splitter>
+          <dc_splitter_1>
+            <power_split units="percent">50.0</power_split>
+          </dc_splitter_1>
+        </DC_splitter>
+        <planetary_gear>
+          <planetary_gear_1>
+            <efficiency is_input="True">0.99<!--Efficiency of the planetary gear--></efficiency>
+            <gear_ratio>1.0</gear_ratio>
+            <power_split units="percent">50.0</power_split>
+            <tech_level_constant is_input="True">0.0<!--Technology level constant for the gearbox, default value computed with the results from the source paper--></tech_level_constant>
+          </planetary_gear_1>
+        </planetary_gear>
+        <PMSM>
+          <motor_1>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">3250.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">830.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_1>
+          <motor_2>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">3250.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">830.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_2>
+        </PMSM>
+        <inverter>
+          <inverter_1>
+            <efficiency_mission>0.98</efficiency_mission>
+            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_1>
+          <inverter_2>
+            <efficiency_mission>0.98</efficiency_mission>
+            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_2>
+        </inverter>
+        <battery_pack>
+          <battery_pack_1>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_1>
+          <battery_pack_2>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_2>
+        </battery_pack>
+      </he_power_train>
+    </propulsion>
+    <aerodynamics>
+      <propeller>
+        <mach is_input="True">0.0<!--mach number used to compute the polar of the airfoil used in the propeller computation--></mach>
+        <reynolds is_input="True">1000000.0<!--reynolds number used to compute the polar of the airfoil used in the propeller computation--></reynolds>
+        <cruise_level>
+          <altitude units="m" is_input="False">2438.4<!--altitude at which the cruise level propeller efficiency map was computed--></altitude>
+          <efficiency is_input="False">[[0.08530005486124256, 0.16829301352015982, 0.19729632102474817, 0.19948091923407776, 0.1919462541607033, 0.18151990502361054, 0.17071828377276843, 0.16055835068023994, 0.1514977491952318, 0.14283249726987826, 0.13461462171811225, 0.12709638574602894, 0.12003000411430331, 0.11350478154756086, 0.10796382230441834, 0.10282339988923522, 0.097776536438269, 0.09183076775470722, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149], [0.21898409717137646, 0.40860062791900587, 0.46627979554573395, 0.47353799840204236, 0.46197538443722513, 0.44395677687579493, 0.4240786363668649, 0.4046711622026329, 0.38679220698271255, 0.3699759641037544, 0.35298941135115025, 0.33717552270609685, 0.3222396600355954, 0.30768374985559105, 0.2941909091689512, 0.2826241789156212, 0.2717196412424635, 0.2611171470407305, 0.24968947461043978, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758], [0.3221821674387253, 0.54705852614785, 0.6094073636176869, 0.6207928152748975, 0.6125811135953867, 0.5963887835661168, 0.5770310730547497, 0.5569800199499474, 0.5378755337393591, 0.5204922804408615, 0.5019162003192688, 0.4838034583336272, 0.46668566213460727, 0.4502992934226298, 0.4333917579715272, 0.41823641941567186, 0.40496247713128364, 0.39215375852322937, 0.3797062616388516, 0.3667018100857163, 0.34991710488525835, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749], [0.3840847534404945, 0.6163723279469772, 0.6816313277992596, 0.6977179055990025, 0.6946876738814904, 0.6832304234487679, 0.6678054537563645, 0.6507730155955819, 0.633471466687619, 0.6180174682694553, 0.6014636738692486, 0.5840687173943357, 0.5673989254129931, 0.5512673208418547, 0.5354907126735293, 0.5189214467882629, 0.5043710925937906, 0.4912194090519666, 0.47837308094399594, 0.46578383617303787, 0.4528986393692126, 0.4367931098904753, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894], [0.4162206845504372, 0.6447180480543131, 0.7135170076505943, 0.7355876092833685, 0.7383238439925945, 0.7321561969119317, 0.7214475048364544, 0.7084832815542957, 0.6944863326765549, 0.6815148523448301, 0.6677208605045626, 0.6526082187226498, 0.6375655318133149, 0.6227682413928755, 0.6084197705521291, 0.5935910882220362, 0.5788231168982322, 0.565638863525112, 0.5532535287577882, 0.5411682790067882, 0.5292177821320938, 0.516983782697819, 0.5023188236684182, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427], [0.4069859818949012, 0.6484424054652869, 0.7229776812708956, 0.751460555371571, 0.759973043525158, 0.7591136433974462, 0.7529751346725001, 0.7440554187834634, 0.7336824494099241, 0.7234821449485286, 0.7122773688030222, 0.6997743309620104, 0.6869201554758978, 0.6739700927993334, 0.6612173003670883, 0.6483048784607617, 0.6349219162681938, 0.622233350869981, 0.6103925901336436, 0.5990528623199329, 0.5879646260227047, 0.5769442973750399, 0.5656497083168188, 0.5525081844483241, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039], [0.3947191962156007, 0.6365944318761548, 0.7202659706653445, 0.7548847315587227, 0.7689894907419799, 0.7730034616768446, 0.771170566163189, 0.7659912585066122, 0.7590769282499837, 0.7515138373399238, 0.74276068665281, 0.7326710070730431, 0.7220380965921961, 0.7110340456352593, 0.699990715817601, 0.6888711738011027, 0.6772095445285499, 0.6656676309390444, 0.6546833775008339, 0.6441323728290667, 0.6338467617699817, 0.6237619702210907, 0.6137156549682009, 0.6034537111765756, 0.5918190142266423, 0.575022851066347, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107], [0.37064153384005905, 0.6215881980042637, 0.711150239324778, 0.7512916886191463, 0.7706039901994188, 0.7789740112273803, 0.7810703885488236, 0.7793150493167846, 0.7754764321313032, 0.7703918081206474, 0.7639289870626179, 0.7560087732505143, 0.7473820938032627, 0.738282542440783, 0.7289114612304615, 0.7193990282090695, 0.7094941378115631, 0.6992647342068092, 0.6893388780495783, 0.6796975040873476, 0.6703012018911672, 0.6610268470504826, 0.6518719626451218, 0.6427420288461364, 0.6334653452524432, 0.6232275001609469, 0.6103811245963924, 0.6036861163374001, 0.6036861163374001, 0.6036861163374001], [0.3549459268348402, 0.6019916951199231, 0.6977553222217443, 0.7439880801720442, 0.7679914676049849, 0.7802746527801914, 0.7857390157782621, 0.7870148735983472, 0.7859366670138092, 0.7831059571064102, 0.7786884236334871, 0.7727834250453334, 0.7659858818955847, 0.7585897018801246, 0.7507943921728022, 0.742749259157464, 0.7343721564942727, 0.7255565313751866, 0.7167064968026865, 0.7080570299514463, 0.6995321238438824, 0.691106653633415, 0.6827668089780798, 0.6744751776147121, 0.6661856211066182, 0.6578098842165556, 0.6487977889029929, 0.6382216448259804, 0.6280241546079525, 0.6280241546079525], [0.3240202709619619, 0.5805271356146239, 0.6832491490506619, 0.734743399347032, 0.7629922010757247, 0.7788244989155665, 0.7872722146120348, 0.79119030253486, 0.7924152171565334, 0.7916024986382685, 0.7890316189418384, 0.7849491522890222, 0.779782668763414, 0.7739140769019306, 0.7675653509203515, 0.7608471433395458, 0.7537952117070004, 0.7463499252428681, 0.738603278788942, 0.7308702107417007, 0.7232405630129382, 0.7156525895027663, 0.7080657977241661, 0.7005420445821557, 0.6930230902659031, 0.6854986187191139, 0.6778985410310467, 0.6699611850296374, 0.6610305809456005, 0.6476421164613491]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at cruise level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at cruise level are computed--></speed>
+          <thrust units="N" is_input="False">[163.447801591381, 456.8832398290857, 750.3186780667904, 1043.7541163044953, 1337.1895545421999, 1630.6249927799045, 1924.0604310176093, 2217.495869255314, 2510.9313074930187, 2804.3667457307233, 3097.802183968428, 3391.237622206133, 3684.6730604438376, 3978.108498681542, 4271.543936919247, 4564.979375156951, 4858.414813394656, 5151.8502516323615, 5445.285689870066, 5738.721128107771, 6032.156566345475, 6325.59200458318, 6619.027442820885, 6912.462881058589, 7205.898319296294, 7499.333757533999, 7792.769195771703, 8086.204634009408, 8379.640072247113, 8673.075510484818]<!--thrust produced by the propeller at cruise level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[5166.687446702883, 5683.084379455381, 6104.941620936745, 6472.966495514782, 6819.855775185387, 7161.545168399918, 7508.616995426542, 7868.808840383192, 8254.67947404465, 8673.075510484818]<!--maximum thrust output of the propeller at cruise level for varying velocities--></thrust_limit>
+        </cruise_level>
+        <sea_level>
+          <efficiency is_input="False">[[0.08559524652103005, 0.16746079374777373, 0.19700334637165667, 0.1997708841011615, 0.19266563931119182, 0.18249945813876728, 0.17187221081889678, 0.16179598598205108, 0.15279191802180817, 0.14420689755285862, 0.1359887975944682, 0.1284682176722167, 0.12142752525910311, 0.11482058873387413, 0.10922456578374536, 0.10409393339502468, 0.09909897012707508, 0.09354611420669316, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878], [0.21946683955857027, 0.4070653813646662, 0.4656512860894166, 0.4738513549980477, 0.4631998668180335, 0.4457605310821373, 0.42627268655372336, 0.40711600630357425, 0.3893980713967947, 0.3728107754376203, 0.35593852900489553, 0.3401588885590199, 0.32527598717498685, 0.31080232316423495, 0.29716167335245053, 0.28550448609430107, 0.27462422109232054, 0.2641024291551355, 0.2530944970363329, 0.23751757158728953, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416], [0.32295240661343527, 0.545587317977352, 0.6086955644209024, 0.621073801322977, 0.6137032720618116, 0.5981852023617394, 0.5793226760693, 0.5596245367201715, 0.5407400664411743, 0.5236415832816252, 0.5053182919871878, 0.487307499402436, 0.4702535847438607, 0.4540024280022737, 0.43725452406498266, 0.42187298218113917, 0.4085683837175746, 0.3958226535019926, 0.3834550018470688, 0.37083713946439095, 0.35511571212452414, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085], [0.38485662650771013, 0.6149284281262366, 0.680928584926233, 0.6979238400830844, 0.6956546136037444, 0.6848044854741254, 0.6698590343459225, 0.6532081849326775, 0.6361431536072055, 0.6210239535985712, 0.6047878596596149, 0.5875558772862273, 0.5710068630367056, 0.5549738893472026, 0.5393703187482276, 0.5229040328056744, 0.5082299514539513, 0.4950863361961832, 0.4823301053823931, 0.4698387692922264, 0.4572267778273543, 0.4419975160654984, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031], [0.41646514016979747, 0.6434352427283466, 0.7128217474307318, 0.7356950909690921, 0.7390073188405037, 0.7334254787546669, 0.7231912616629405, 0.7106049759583282, 0.6969631753296891, 0.6842245814347332, 0.6707300634702648, 0.6558518245385779, 0.6409675406536163, 0.6263010174428982, 0.6120891019859229, 0.5974565305343131, 0.5826787040317936, 0.5694960837894123, 0.5571698893121968, 0.5451634650356759, 0.5333257323912791, 0.5212968187573547, 0.5073397562276435, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998], [0.409455378135157, 0.6473345846622222, 0.7223147863600431, 0.7514764752690146, 0.7605036797131038, 0.7601721845258685, 0.7544204997326877, 0.7458851729668731, 0.7358617896966939, 0.7259313436535808, 0.7149986021712363, 0.7026942311022902, 0.6900289608728961, 0.6772297533647824, 0.6646183122217576, 0.6518790959788052, 0.6385848136034126, 0.6259679819780883, 0.6141778123645895, 0.6029121762392661, 0.5919030780374738, 0.5809818952622033, 0.5698720398613432, 0.557217324025475, 0.5372944491852183, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414], [0.3953312638004441, 0.6358115370524278, 0.7196996332074858, 0.7548432086869586, 0.7694092269011428, 0.773832881644416, 0.7724242657122274, 0.7675665995019243, 0.7610074890956313, 0.7537129129619586, 0.7451907098452001, 0.7353012807651571, 0.7248475866981763, 0.714015272638944, 0.7031205982212984, 0.692145975087162, 0.6806184723781162, 0.6691779531618413, 0.658279803844729, 0.6478016191218834, 0.637599039386411, 0.6275947375293485, 0.6176408964767897, 0.6075142201040424, 0.5962206004520426, 0.5813318776712864, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875], [0.37502214790548005, 0.621513702458121, 0.7106598336732024, 0.7512486934842537, 0.7709687399998211, 0.7797129768048593, 0.7821466237893939, 0.7807195992387596, 0.777239236257852, 0.7724066683263304, 0.7661288703458095, 0.7584143086559684, 0.7499418418991161, 0.7410174056290642, 0.7318034765974706, 0.7224233087124184, 0.7126289298037244, 0.7025142675967138, 0.6927099445099428, 0.6831584952387556, 0.6738623108724029, 0.6646719000901224, 0.6556001557389005, 0.6465481583464296, 0.6373780578932061, 0.6273363973051153, 0.6150016987364886, 0.6057495835080302, 0.6057495835080302, 0.6057495835080302], [0.35508508960321633, 0.601405382049293, 0.6973966914478564, 0.7439989072630241, 0.7683660336108185, 0.7809881021710351, 0.7867626680387921, 0.7883464328502263, 0.7875783300712109, 0.7850084714489851, 0.7807432930120342, 0.7750217914073025, 0.7683659693251536, 0.7611277284841014, 0.7534858390350037, 0.7455796856748332, 0.7373097504283624, 0.728602057524929, 0.7198716458340264, 0.7113281930517014, 0.702903445541824, 0.6945660765205901, 0.6863239840190664, 0.6781044656160994, 0.6698991214263045, 0.6615946458117216, 0.6526938773741703, 0.6422847359663604, 0.6303181609714937, 0.6303181609714937], [0.32688741261648224, 0.5804727423083644, 0.6831129180397443, 0.7348673233187948, 0.7634321345443952, 0.7795721244454902, 0.7882882658060564, 0.7925302028986236, 0.794015043273824, 0.7934572457863657, 0.7909915389033304, 0.7870631908251293, 0.7820364066960803, 0.776325135869199, 0.770123944795257, 0.7635379460083411, 0.756583439306165, 0.7492190954094681, 0.7415941988825705, 0.7339711052029734, 0.7264464102959793, 0.7189606778007763, 0.7114646261817927, 0.7040172063029317, 0.6965813695746137, 0.6891321045957475, 0.6815952960622204, 0.67369851983467, 0.6648170015283738, 0.6502311380843497]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at sea level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at sea level are computed--></speed>
+          <thrust units="N" is_input="False">[208.48223431412015, 575.2513628160312, 942.0204913179423, 1308.7896198198534, 1675.5587483217646, 2042.3278768236758, 2409.0970053255865, 2775.866133827498, 3142.6352623294088, 3509.4043908313197, 3876.173519333231, 4242.942647835142, 4609.711776337053, 4976.480904838964, 5343.250033340876, 5710.019161842787, 6076.788290344698, 6443.557418846609, 6810.32654734852, 7177.095675850432, 7543.864804352343, 7910.6339328542535, 8277.403061356164, 8644.172189858076, 9010.941318359986, 9377.710446861898, 9744.479575363808, 10111.24870386572, 10478.017832367632, 10844.786960869542]<!--thrust produced by the propeller at sea level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[6533.840174009261, 7181.649624427429, 7704.744804457652, 8163.379307607336, 8591.84017293703, 9012.766951506735, 9435.643628430062, 9874.443915635982, 10339.44635971018, 10844.786960869542]<!--maximum thrust output of the propeller at sea level for varying velocities--></thrust_limit>
+        </sea_level>
+      </propeller>
+    </aerodynamics>
+    <handling_qualities>
+      <static_margin>
+        <target>0.15<!--static margin we want to achieve--></target>
+      </static_margin>
+    </handling_qualities>
+    <mission>
+      <sizing>
+        <initial_climb>
+          <energy units="W*h">0.0</energy>
+          <fuel units="kg">0.0</fuel>
+        </initial_climb>
+        <landing>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during landing--></elevator_angle>
+          <flap_angle units="deg">30.0<!--position of the flaps during landing--></flap_angle>
+          <target_sideslip units="deg">15.0</target_sideslip>
+        </landing>
+        <takeoff>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during takeoff--></elevator_angle>
+          <energy units="W*h">0.0</energy>
+          <flap_angle units="deg">10.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
+          <fuel units="kg">0.0</fuel>
+          <thrust_rate>1.0<!--thrust rate during takeoff phase--></thrust_rate>
+        </takeoff>
+        <taxi_in>
+          <duration units="s">300.0<!--duration of taxi-in phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-in phase in sizing mission--></speed>
+        </taxi_in>
+        <taxi_out>
+          <duration units="s">300.0<!--duration of taxi-out phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-out phase in sizing mission--></speed>
+        </taxi_out>
+        <cs23>
+          <characteristic_speed>
+            <vd units="kn">202.6<!--limit speed--></vd>
+          </characteristic_speed>
+          <sizing_factor>
+            <ultimate_aircraft>5.7<!--ultimate load factor that the aircraft will experience (default value is 5.7)--></ultimate_aircraft>
+          </sizing_factor>
+        </cs23>
+        <main_route>
+          <cruise>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
+          </cruise>
+          <descent>
+            <descent_rate units="ft/min">-500.0<!--target descent rate for the aircraft--></descent_rate>
+          </descent>
+          <reserve>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
+            <duration units="min">45.0<!--duration of the reserve segment--></duration>
+          </reserve>
+          <climb>
+            <climb_rate>
+              <cruise_level units="ft/min">1170.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+            </climb_rate>
+          </climb>
+        </main_route>
+      </sizing>
+    </mission>
+    <weight>
+      <airframe>
+        <fuselage>
+          <k_factor>1.0<!--proportional corrective factor for fuselage mass--></k_factor>
+        </fuselage>
+        <horizontal_tail>
+          <k_factor>1.0<!--proportional corrective factor for horizontal tail mass--></k_factor>
+        </horizontal_tail>
+        <paint>
+          <mass units="lbm">1.0<!--Mass of the airframe_inp_data:weight:airframe:paint:mass--></mass>
+        </paint>
+        <vertical_tail>
+          <k_factor>1.0<!--proportional corrective factor for vertical tail mass--></k_factor>
+        </vertical_tail>
+        <wing>
+          <k_factor>0.9<!--proportional corrective factor for wing mass--></k_factor>
+        </wing>
+      </airframe>
+      <propulsion>
+        <engine>
+          <mass units="lbm">731.6708415039819<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
+        </engine>
+        <fuel_lines>
+          <mass units="lbm">71.48274780115939<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
+        </fuel_lines>
+        <unusable_fuel>
+          <mass units="lbm">0.0<!--total unusable fuel mass--></mass>
+        </unusable_fuel>
+      </propulsion>
+      <systems>
+        <power>
+          <electric_systems>
+            <mass units="lbm">189.12923759516593<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="lbm">25.5648480458697<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+  </data>
+  <settings>
+    <handling_qualities>
+      <rudder>
+        <safety_margin>0.2<!--Ratio of the total rudder deflection not used in the computation of the VT area to leave a safety margin--></safety_margin>
+      </rudder>
+    </handling_qualities>
+    <propulsion>
+      <IC_engine>
+        <k_factor_sfc>1.0<!--k_factor that can be used to adjust the consumption on engine level to the aircraft level--></k_factor_sfc>
+      </IC_engine>
+      <he_power_train>
+        <ICE>
+          <ice_1>
+            <cg_in_nacelle>0.9<!--Location of the engine CG in the nacelle, in percent of the nacelle length--></cg_in_nacelle>
+            <k_sfc>1.0<!--K-factor to adjust the sfc of the ICE--></k_sfc>
+          </ice_1>
+        </ICE>
+      </he_power_train>
+    </propulsion>
+    <weight>
+      <aircraft>
+        <CG>
+          <range>0.217<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg">80.0<!--design payload mass carried by passenger--></design_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <landing_gear>
+          <front>
+            <weight_ratio>0.13<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+          </front>
+        </landing_gear>
+      </airframe>
+      <propulsion>
+        <tank>
+          <CG>
+            <from_wingMAC25>0.25<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
+          </CG>
+        </tank>
+      </propulsion>
+    </weight>
+    <mission>
+      <sizing>
+        <main_route>
+          <reserve>
+            <speed>
+              <k_factor is_input="True">1.3<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+            </speed>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+  </settings>
+  <convergence>
+    <propulsion>
+      <he_power_train>
+        <propeller>
+          <propeller_1>
+            <min_power units="kW" is_input="True">5.0<!--Convergence parameter used to aid convergence since, if power is too low in the network, the code will have trouble converging--></min_power>
+          </propeller_1>
+        </propeller>
+      </he_power_train>
+    </propulsion>
+  </convergence>
+</FASTOAD_model>

--- a/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_electric_two_motors.xml
@@ -390,8 +390,8 @@
           </reserve>
           <climb>
             <climb_rate>
-              <cruise_level units="ft/min">1170.0<!--target climb rate at the end of climb--></cruise_level>
-              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+              <cruise_level units="ft/min">1300.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
             </climb_rate>
           </climb>
         </main_route>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -385,7 +385,7 @@
         <planetary_gear>
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
-            <power_share units="kW">160.0</power_share>
+            <power_share units="kW" is_input="True">161.8421052631579<!--Share of the power going to the first (primary) input, in W--></power_share>
             <power_split units="percent">90.0</power_split>
           </planetary_gear_1>
         </planetary_gear>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -234,8 +234,156 @@
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
             <power_split units="percent">90.0</power_split>
+            <power_share units="kW">205.0</power_share>
           </planetary_gear_1>
         </planetary_gear>
+        <DC_DC_converter>
+          <dc_dc_converter_1>
+            <efficiency_mission>0.98</efficiency_mission>
+            <current_in_caliber units="A" is_input="False">351.92755740781257<!--Current caliber of one arm of the DC/DC converter--></current_in_caliber>
+            <current_in_max units="A" is_input="False">351.92726177987004</current_in_max>
+            <dissipable_heat units="W" is_input="False">3159.4391723772824<!--Maximum power losses of the inverter (all modules)--></dissipable_heat>
+            <front_length_ratio is_input="True">0.9<!--Location of the DC/DC converter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <losses_max units="W" is_input="False">3159.4298955354134</losses_max>
+            <mass units="kg" is_input="False">4.1453782213319466<!--Mass of the converter--></mass>
+            <power_density units="kW/kg" is_input="False">69.9546077151102<!--Power density of the DC/DC converter--></power_density>
+            <switching_frequency units="Hz" is_input="False">12000.0<!--Maximum switching frequency of the IGBT module in the converter--></switching_frequency>
+            <switching_frequency_max units="Hz" is_input="False">12000.0<!--Maximum switching frequency seen during the mission in the converter--></switching_frequency_max>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the DC/DC converter for the points--></switching_frequency_mission>
+            <voltage_caliber units="V" is_input="False">824.0<!--Voltage caliber of the converter--></voltage_caliber>
+            <voltage_in_caliber units="V" is_input="False">824.0</voltage_in_caliber>
+            <voltage_in_max units="V" is_input="False">824.0</voltage_in_max>
+            <voltage_out_max units="V" is_input="False">800.0</voltage_out_max>
+            <voltage_out_target_mission units="V" is_input="True">800.0<!--Target output voltage of the DC/DC converter for the points--></voltage_out_target_mission>
+            <voltage_ripple is_input="True">0.02<!--Amplitude of the voltage ripple as a percent of the voltage caliber--></voltage_ripple>
+            <CG>
+              <x units="m" is_input="False">2.07<!--X position of the DC/DC converter center of gravity--></x>
+              <y units="m" is_input="False">0.0<!--Y position of the DC bus center of gravity--></y>
+            </CG>
+            <capacitor>
+              <aspect_ratio is_input="True">1.0<!--Ratio of the capacitor diameter over its height--></aspect_ratio>
+              <capacity units="F" is_input="False">0.00040515996676537895<!--Capacity of the capacitor--></capacity>
+              <current_caliber units="A" is_input="False">320.4977401100854<!--Current caliber of the DC/DC converter--></current_caliber>
+              <current_max units="A" is_input="False">320.49762067475444</current_max>
+              <diameter units="mm" is_input="False">73.99610198394527<!--Diameter of the capacitor--></diameter>
+              <height units="mm" is_input="False">73.99610198394527<!--Diameter of the capacitor--></height>
+              <mass units="kg" is_input="False">0.3920902904181088<!--Capacitor's mass--></mass>
+              <resistance units="ohm" is_input="False">0.005844297210285445<!--Capacitor's resistance--></resistance>
+              <thermal_resistance units="degK/W" is_input="False">4.691981724310422<!--Capacitor's thermal resistance--></thermal_resistance>
+              <scaling>
+                <capacity is_input="False">0.40515996676537896<!--Scaling factor for the capacitor capacity--></capacity>
+                <diameter is_input="False">0.7399610198394526<!--Scaling factor for the capacitor diameter--></diameter>
+                <height is_input="False">0.477394206348034<!--Scaling factor for the capacitor height--></height>
+                <mass is_input="False">0.26139352694540585<!--Scaling factor for the capacitor mass--></mass>
+                <resistance is_input="False">1.8263428782142017<!--Scaling factor for the capacitor resistance--></resistance>
+                <thermal_resistance is_input="False">1.563993908103474<!--Scaling factor for the capacitor thermal resistance--></thermal_resistance>
+              </scaling>
+            </capacitor>
+            <contactor>
+              <mass units="kg" is_input="False">1.4000571525464165<!--Mass of the contactor--></mass>
+            </contactor>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <cruise>
+              <CD0 is_input="False">0.0</CD0>
+            </cruise>
+            <diode>
+              <current_max units="A" is_input="False">439.7897102673842</current_max>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+              <resistance units="ohm" is_input="False">0.0017881410066921163</resistance>
+            </diode>
+            <energy_off>
+              <a is_input="False">0.014413782151712046</a>
+              <b is_input="False">0.0002539092853205021</b>
+              <c is_input="False">-1.8186699082646406e-07</c>
+            </energy_off>
+            <energy_on>
+              <a is_input="False">0.015168462465791361</a>
+              <b is_input="False">3.3256504177779456e-05</b>
+              <c is_input="False">5.369737476537379e-07</c>
+            </energy_on>
+            <energy_rr>
+              <a is_input="False">0.0040621971028159546</a>
+              <b is_input="False">0.00034030311012866587</b>
+              <c is_input="False">-4.71819204800918e-08</c>
+            </energy_rr>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <height units="m" is_input="False">0.004467651530300808<!--Height of the heat sink--></height>
+              <length units="m" is_input="False">0.07150000000000001<!--Length of the heat sink--></length>
+              <mass units="kg" is_input="False">0.16867680357199324<!--Mass of the heat sink, includes tubes and core--></mass>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <width units="m" is_input="False">0.17865526963516062<!--Width of the heat sink--></width>
+              <coolant>
+                <Prandtl_number is_input="False">39.493034825870645<!--Prandtl number of the coolant--></Prandtl_number>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <max_mass_flow units="m**3/s" is_input="False">2.9856842894674356e-05<!--Maximum mass flow necessary to cool the inverter--></max_mass_flow>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <inner_diameter units="m" is_input="False">0.0004784343535338718<!--Inner diameter of the tube for the cooling of the inverter--></inner_diameter>
+                <length units="m" is_input="False">0.28600000000000003<!--Length of the tube which is useful for the cooling of the inverter--></length>
+                <mass units="kg" is_input="False">0.019970350603740892<!--Wieght of the tube for the cooling of the inverter--></mass>
+                <outer_diameter units="m" is_input="False">0.0029784343535338717<!--Outer diameter of the tube for the cooling of the inverter--></outer_diameter>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <current_max units="A" is_input="False">470.600156492483</current_max>
+              <resistance units="ohm" is_input="False">0.0014438999572754523</resistance>
+            </igbt>
+            <inductor>
+              <air_gap units="m" is_input="False">0.0023290059485161856<!--Air gap in the inductor--></air_gap>
+              <copper_mass units="kg" is_input="False">0.2214427610383174<!--Mass of the copper in the inductor--></copper_mass>
+              <core_mass units="kg" is_input="False">0.299935512674498<!--Mass of the E-core in the inductor--></core_mass>
+              <current_caliber units="A" is_input="False">642.2374026417449<!--Current caliber of the DC/DC converter--></current_caliber>
+              <current_max units="A" is_input="False">642.2371567118598</current_max>
+              <inductance units="H" is_input="True">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+              <iron_surface units="m**2" is_input="False">0.000529879366946287<!--Iron surface of the E-core inductor--></iron_surface>
+              <magnetic_energy_rating units="J" is_input="False">0.28073070919333326<!--Maximum magnetic energy that can be stored in the inductors--></magnetic_energy_rating>
+              <magnetic_field units="T" is_input="True">1.0<!--Magnetic field in the inductor core, will be taken at its maximum allowable value to reduce the weight--></magnetic_field>
+              <mass units="kg" is_input="False">0.8213137863873133<!--Mass of the inductor--></mass>
+              <reluctance units="1/H" is_input="False">1999704.8544663598<!--Reluctance of the inductor--></reluctance>
+              <resistance units="ohm" is_input="False">3.0457129597536353e-05<!--Resistance of the inductor--></resistance>
+              <turn_number is_input="False">1.6498608427437274<!--Number of turns in the inductor--></turn_number>
+              <wire_current_density units="A/m**2" is_input="True">5000000.0<!--Maximum current density allowed in the copper wire--></wire_current_density>
+              <wire_section_area units="m**2" is_input="False">0.00012844748052834898<!--Section area of the copper wire inside the inductor--></wire_section_area>
+              <core_dimension>
+                <B units="m" is_input="False">0.06198329422278384<!--B dimension of the E-core in the inductor--></B>
+                <C units="m" is_input="False">0.02330199030931723<!--C dimension of the E-core in the inductor--></C>
+              </core_dimension>
+              <scaling>
+                <core_dimension is_input="False">0.8473451021569902<!--Scaling factor for the dimensions of the E-core--></core_dimension>
+                <core_mass is_input="False">0.6083884638427951<!--Scaling factor for the mass of the E-core--></core_mass>
+              </scaling>
+            </inductor>
+            <low_speed>
+              <CD0 is_input="False">0.0</CD0>
+            </low_speed>
+            <module>
+              <current_caliber units="A" is_input="False">470.60047102028693<!--Current caliber of the DC/DC converter--></current_caliber>
+              <height units="m" is_input="False">0.021<!--Height of one module--></height>
+              <length units="m" is_input="False">0.16241388148650965<!--Length of one module--></length>
+              <mass units="kg" is_input="False">0.3632401884081148<!--Weight of the diode and IGBT module--></mass>
+              <number is_input="True">1.0<!--Number of module to cool down, will depend on the component (3 for inverter/rectifiers, 1 for DC/DC)--></number>
+              <width units="m" is_input="False">0.065<!--Width of one module--></width>
+            </module>
+            <scaling>
+              <a is_input="False">0.9562251372685114</a>
+              <c is_input="False">1.0457788244895265</c>
+              <resistance is_input="False">0.9562251372685114</resistance>
+            </scaling>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+          </dc_dc_converter_1>
+        </DC_DC_converter>
         <battery_pack>
           <battery_pack_1>
             <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
@@ -324,8 +472,8 @@
           </reserve>
           <climb>
             <climb_rate>
-              <cruise_level units="ft/min">790.0<!--target climb rate at the end of climb--></cruise_level>
-              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+              <cruise_level units="ft/min">922.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1398.0<!--target climb rate at sea level--></sea_level>
             </climb_rate>
           </climb>
         </main_route>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -383,7 +383,7 @@
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
             <power_share units="kW" is_input="True">150.<!--Share of the power going to the first (primary) input, in W--></power_share>
-            <power_split units="percent">90.0</power_split>
+            <power_split units="percent">88.0</power_split>
           </planetary_gear_1>
         </planetary_gear>
         <propeller>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -383,7 +383,7 @@
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
             <power_share units="kW" is_input="True">150.<!--Share of the power going to the first (primary) input, in W--></power_share>
-            <power_split units="percent">88.0</power_split>
+            <power_split units="percent">81.0</power_split>
           </planetary_gear_1>
         </planetary_gear>
         <propeller>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -11,7 +11,7 @@
     <geometry>
       <flap_type>1.0<!--flap type (0.0 - plain flap, 2.0 - single slotted flap, 3.0 - split flap)--></flap_type>
       <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
-      <wing_configuration>1.0</wing_configuration>
+      <wing_configuration>1.0<!--1=low wing configuration / 2=mid wing configuration / 3=high wing configuration--></wing_configuration>
       <cabin>
         <aisle_width units="m">0.0<!--width of aisles--></aisle_width>
         <luggage>
@@ -78,10 +78,10 @@
         <area units="m**2">13.46<!--wing reference area--></area>
         <aspect_ratio>10.12<!--wing aspect ratio--></aspect_ratio>
         <dihedral units="deg">5.0</dihedral>
-        <twist units="deg">0.0</twist>
         <sweep_25 units="deg">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
         <taper_ratio>0.5<!--taper ratio of wing--></taper_ratio>
         <thickness_ratio>0.12<!--mean thickness ratio of wing--></thickness_ratio>
+        <twist units="deg">0.0</twist>
         <aileron>
           <chord_ratio>0.25<!--aileron chord as a percentage of the wing chord--></chord_ratio>
           <max_deflection units="deg">30.0</max_deflection>
@@ -120,129 +120,12 @@
       </IC_engine>
       <he_power_train>
         <thrust_distribution>1.0</thrust_distribution>
-        <ICE>
-          <ice_1>
-            <pme_max units="bar">20.62<!--Maximum Mean Effective Pressure in the ICE cylinders--></pme_max>
-            <power_rating_SL units="W">231000.0<!--Maximum power the motor can provide at Sea Level--></power_rating_SL>
-            <rpm_max units="1/min">2700.0<!--Maximum RPM on the shaft of the engine--></rpm_max>
-            <strokes_number>4.0</strokes_number>
-          </ice_1>
-        </ICE>
-        <fuel_system>
-          <fuel_system_1>
-            <fuel_distribution>[1.0, 1.0]</fuel_distribution>
-            <fuel_type>1.0<!--Type of fuel flowing in the system, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
-          </fuel_system_1>
-        </fuel_system>
-        <fuel_tank>
-          <fuel_tank_1>
-            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
-            <CG>
-              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
-            </CG>
-          </fuel_tank_1>
-          <fuel_tank_2>
-            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
-            <CG>
-              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
-            </CG>
-          </fuel_tank_2>
-        </fuel_tank>
-        <propeller>
-          <propeller_1>
-            <activity_factor>128.6<!--Activity factor of the propeller--></activity_factor>
-            <blade_twist units="deg">17.8<!--Twist between the propeller blade root and tip--></blade_twist>
-            <depth_to_diameter_ratio>0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
-            <diameter units="m">1.98<!--Diameter of the propeller--></diameter>
-            <installation_angle units="deg">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
-            <material>0.0<!--1.0 for composite, 0.0 for aluminium--></material>
-            <number_blades>3.0<!--Number of blades on the propeller--></number_blades>
-            <rpm_mission units="1/min">2500.0</rpm_mission>
-            <solidity>0.13517604<!--Solidity of the propeller--></solidity>
-          </propeller_1>
-        </propeller>
-        <DC_cable_harness>
-          <harness_1>
-            <cable_temperature_mission units="degK">303.15</cable_temperature_mission>
-          </harness_1>
-        </DC_cable_harness>
-        <PMSM>
-          <motor_1>
-            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
-            <rpm_rating units="1/min" is_input="True">8000.0<!--Max voltage of the motor--></rpm_rating>
-            <voltage_caliber units="V" is_input="True">660.0<!--Max voltage of the motor--></voltage_caliber>
-          </motor_1>
-        </PMSM>
-        <inverter>
-          <inverter_1>
-            <efficiency_mission>0.98</efficiency_mission>
-            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
-            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
-            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
-            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
-            <power_factor is_input="True">1.0</power_factor>
-            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
-            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
-            <control_card>
-              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
-            </control_card>
-            <diode>
-              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
-            </diode>
-            <heat_sink>
-              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
-              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
-              <coolant>
-                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
-                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
-                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
-                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
-                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
-                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
-              </coolant>
-              <tube>
-                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
-                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
-              </tube>
-            </heat_sink>
-            <igbt>
-              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
-            </igbt>
-            <capacitor>
-              <aspect_ratio>2.0</aspect_ratio>
-            </capacitor>
-            <inductor>
-              <air_gap units="mm">2.7</air_gap>
-              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
-            </inductor>
-            <tube>
-              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
-            </tube>
-            <properties>
-              <resistance_temperature_scale_factor>
-                <diode units="1/degK" is_input="True">0.0033</diode>
-                <igbt units="1/degK" is_input="True">0.0041</igbt>
-              </resistance_temperature_scale_factor>
-              <voltage_temperature_scale_factor>
-                <diode units="1/degK" is_input="True">-0.0022</diode>
-                <igbt units="1/degK" is_input="True">-0.00105</igbt>
-              </voltage_temperature_scale_factor>
-            </properties>
-          </inverter_1>
-        </inverter>
-        <planetary_gear>
-          <planetary_gear_1>
-            <gear_ratio>1.0</gear_ratio>
-            <power_split units="percent">90.0</power_split>
-            <power_share units="kW">205.0</power_share>
-          </planetary_gear_1>
-        </planetary_gear>
         <DC_DC_converter>
           <dc_dc_converter_1>
-            <efficiency_mission>0.98</efficiency_mission>
             <current_in_caliber units="A" is_input="False">351.92755740781257<!--Current caliber of one arm of the DC/DC converter--></current_in_caliber>
             <current_in_max units="A" is_input="False">351.92726177987004</current_in_max>
             <dissipable_heat units="W" is_input="False">3159.4391723772824<!--Maximum power losses of the inverter (all modules)--></dissipable_heat>
+            <efficiency_mission>0.98</efficiency_mission>
             <front_length_ratio is_input="True">0.9<!--Location of the DC/DC converter CG as a ratio of the aircraft front length--></front_length_ratio>
             <losses_max units="W" is_input="False">3159.4298955354134</losses_max>
             <mass units="kg" is_input="False">4.1453782213319466<!--Mass of the converter--></mass>
@@ -384,21 +267,141 @@
             </tube>
           </dc_dc_converter_1>
         </DC_DC_converter>
+        <DC_cable_harness>
+          <harness_1>
+            <cable_temperature_mission units="degK">303.15</cable_temperature_mission>
+          </harness_1>
+        </DC_cable_harness>
+        <ICE>
+          <ice_1>
+            <pme_max units="bar">20.62<!--Maximum Mean Effective Pressure in the ICE cylinders--></pme_max>
+            <power_rating_SL units="W">231000.0<!--Maximum power the motor can provide at Sea Level--></power_rating_SL>
+            <rpm_max units="1/min">2700.0<!--Maximum RPM on the shaft of the engine--></rpm_max>
+            <strokes_number>4.0</strokes_number>
+          </ice_1>
+        </ICE>
+        <PMSM>
+          <motor_1>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">4000.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">660.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_1>
+        </PMSM>
         <battery_pack>
           <battery_pack_1>
             <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
             <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
             <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
             <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
-            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
-            <module>
-              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
-            </module>
+            <number_modules>20</number_modules>
             <CG>
               <y_ratio>0.5</y_ratio>
             </CG>
+            <cell>
+              <c_rate_caliber units="min**-1">8.0</c_rate_caliber>
+            </cell>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
           </battery_pack_1>
         </battery_pack>
+        <fuel_system>
+          <fuel_system_1>
+            <fuel_distribution>[1.0, 1.0]</fuel_distribution>
+            <fuel_type>1.0<!--Type of fuel flowing in the system, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+          </fuel_system_1>
+        </fuel_system>
+        <fuel_tank>
+          <fuel_tank_1>
+            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <CG>
+              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+          </fuel_tank_1>
+          <fuel_tank_2>
+            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <CG>
+              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+          </fuel_tank_2>
+        </fuel_tank>
+        <inverter>
+          <inverter_1>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <efficiency_mission>0.98</efficiency_mission>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_1>
+        </inverter>
+        <planetary_gear>
+          <planetary_gear_1>
+            <gear_ratio>1.0</gear_ratio>
+            <power_share units="kW">180.0</power_share>
+            <power_split units="percent">90.0</power_split>
+          </planetary_gear_1>
+        </planetary_gear>
+        <propeller>
+          <propeller_1>
+            <activity_factor>128.6<!--Activity factor of the propeller--></activity_factor>
+            <blade_twist units="deg">17.8<!--Twist between the propeller blade root and tip--></blade_twist>
+            <depth_to_diameter_ratio>0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="m">1.98<!--Diameter of the propeller--></diameter>
+            <installation_angle units="deg">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
+            <material>0.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades>3.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_mission units="1/min">2500.0</rpm_mission>
+            <solidity>0.13517604<!--Solidity of the propeller--></solidity>
+          </propeller_1>
+        </propeller>
       </he_power_train>
     </propulsion>
     <aerodynamics>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -382,7 +382,7 @@
         <planetary_gear>
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
-            <power_share units="kW" is_input="True">150.<!--Share of the power going to the first (primary) input, in W--></power_share>
+            <power_share units="kW" is_input="True">190.<!--Share of the power going to the first (primary) input, in W--></power_share>
             <power_split units="percent">81.0</power_split>
           </planetary_gear_1>
         </planetary_gear>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -1,0 +1,436 @@
+<FASTOAD_model>
+  <data>
+    <TLAR>
+      <NPAX_design>2.0<!--design number of passengers (two pilots are included de facto, meaning for a 2 seater, NPAX_design is equal to 0)--></NPAX_design>
+      <luggage_mass_design units="kg">55.0<!--luggage design mass--></luggage_mass_design>
+      <range units="NM">200.0<!--top-level requirement: design range--></range>
+      <v_approach units="kn">79.0<!--approach speed--></v_approach>
+      <v_cruise units="kn">160.0<!--cruise speed--></v_cruise>
+      <v_max_sl units="kn" is_input="True">186.0<!--maximum speed at sea level--></v_max_sl>
+    </TLAR>
+    <geometry>
+      <flap_type>1.0<!--flap type (0.0 - plain flap, 2.0 - single slotted flap, 3.0 - split flap)--></flap_type>
+      <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <wing_configuration>1.0</wing_configuration>
+      <cabin>
+        <aisle_width units="m">0.0<!--width of aisles--></aisle_width>
+        <luggage>
+          <mass_max units="kg">60.0<!--maximum luggage mass--></mass_max>
+        </luggage>
+        <seats>
+          <passenger>
+            <NPAX_max>2.0<!--maximum number of passengers in the aircraft--></NPAX_max>
+            <count_by_row>3.0<!--number of passenger seats per row--></count_by_row>
+            <length units="m">1.1<!--passenger seats length--></length>
+            <width units="m">0.4<!--width of passenger seats--></width>
+          </passenger>
+          <pilot>
+            <length units="m">1.05<!--pilot seats length--></length>
+            <width units="m">0.565<!--width of pilot seats--></width>
+          </pilot>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio>0.25<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio>0.53<!--ratio (width of flaps)/(total span)--></span_ratio>
+      </flap>
+      <horizontal_tail>
+        <area units="m**2">2.75<!--horizontal tail area--></area>
+        <aspect_ratio is_input="False">5.47<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <elevator_chord_ratio>0.3<!--elevator chord ratio--></elevator_chord_ratio>
+        <sweep_25 units="deg">4.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio>0.613<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">3.91<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </horizontal_tail>
+      <landing_gear>
+        <type>0.0<!--0=non-retractable / 1=retractable--></type>
+      </landing_gear>
+      <propeller>
+        <depth units="m">0.3<!--depth of the propeller--></depth>
+        <diameter units="m">1.98<!--propeller diameter--></diameter>
+      </propeller>
+      <vertical_tail>
+        <area units="m**2">1.51<!--vertical tail area--></area>
+        <aspect_ratio>2.0<!--aspect ratio of vertical tail--></aspect_ratio>
+        <sweep_25 units="deg">10.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio>0.502<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio>0.1<!--thickness ratio of vertical tail--></thickness_ratio>
+        <rudder>
+          <chord_ratio>0.33<!--flap rudder as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">20.0<!--rudder maximum deflection--></max_deflection>
+        </rudder>
+        <MAC>
+          <at25percent>
+            <x>
+              <from_wingMAC25 units="m">4.41<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
+            </x>
+          </at25percent>
+        </MAC>
+      </vertical_tail>
+      <wing>
+        <area units="m**2">13.46<!--wing reference area--></area>
+        <aspect_ratio>10.12<!--wing aspect ratio--></aspect_ratio>
+        <dihedral units="deg">5.0</dihedral>
+        <twist units="deg">0.0</twist>
+        <sweep_25 units="deg">0.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <taper_ratio>0.5<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio>0.12<!--mean thickness ratio of wing--></thickness_ratio>
+        <aileron>
+          <chord_ratio>0.25<!--aileron chord as a percentage of the wing chord--></chord_ratio>
+          <max_deflection units="deg">30.0</max_deflection>
+          <span_ratio>0.24</span_ratio>
+        </aileron>
+        <kink>
+          <span_ratio>0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+        </kink>
+        <MAC>
+          <at25percent>
+            <x units="m">2.65<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
+          </at25percent>
+        </MAC>
+      </wing>
+      <propulsion>
+        <engine>
+          <count>1.0<!--number of engines--></count>
+          <layout>3.0<!--position of engines (1=under the wing / 2=rear fuselage / 3=nose)--></layout>
+          <y_ratio>0.0<!--engine position with respect to total span--></y_ratio>
+        </engine>
+        <nacelle>
+          <height units="m" is_input="False">0.7546659597502833<!--height of the nacelle--></height>
+          <length units="m" is_input="False">1.148849535217935<!--length of the nacelle--></length>
+          <master_cross_section units="m**2" is_input="False">0.8492852704999014</master_cross_section>
+          <wet_area units="m**2" is_input="False">4.3197777006580775<!--nacelle wet area--></wet_area>
+          <width units="m" is_input="False">1.1253790627855103<!--width of the nacelle--></width>
+        </nacelle>
+      </propulsion>
+    </geometry>
+    <propulsion>
+      <fuel_type>1.0<!--engine fuel type (1.0 - gasoline, 2.0 - gasoil)--></fuel_type>
+      <max_rpm units="min**-1">2700.0<!--maximum number of rotation per minute on the engine--></max_rpm>
+      <IC_engine>
+        <max_power units="W">231000.0<!--maximum power of the engine--></max_power>
+        <strokes_nb>4.0<!--number of strokes on the engine--></strokes_nb>
+      </IC_engine>
+      <he_power_train>
+        <thrust_distribution>1.0</thrust_distribution>
+        <ICE>
+          <ice_1>
+            <pme_max units="bar">20.62<!--Maximum Mean Effective Pressure in the ICE cylinders--></pme_max>
+            <power_rating_SL units="W">231000.0<!--Maximum power the motor can provide at Sea Level--></power_rating_SL>
+            <rpm_max units="1/min">2700.0<!--Maximum RPM on the shaft of the engine--></rpm_max>
+            <strokes_number>4.0</strokes_number>
+          </ice_1>
+        </ICE>
+        <fuel_system>
+          <fuel_system_1>
+            <fuel_distribution>[1.0, 1.0]</fuel_distribution>
+            <fuel_type>1.0<!--Type of fuel flowing in the system, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+          </fuel_system_1>
+        </fuel_system>
+        <fuel_tank>
+          <fuel_tank_1>
+            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <CG>
+              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+          </fuel_tank_1>
+          <fuel_tank_2>
+            <fuel_type>1.0<!--Type of fuel stored in the tank, 1.0 - gasoline, 2.0 - Diesel, 3.0 - Jet A1--></fuel_type>
+            <CG>
+              <y_ratio>0.4<!--Y position of the fuel tank center of gravity as a ratio of the wing half-span--></y_ratio>
+            </CG>
+          </fuel_tank_2>
+        </fuel_tank>
+        <propeller>
+          <propeller_1>
+            <activity_factor>128.6<!--Activity factor of the propeller--></activity_factor>
+            <blade_twist units="deg">17.8<!--Twist between the propeller blade root and tip--></blade_twist>
+            <depth_to_diameter_ratio>0.15<!--Ratio between the propeller depth and propeller diameter, default at 0.15--></depth_to_diameter_ratio>
+            <diameter units="m">1.98<!--Diameter of the propeller--></diameter>
+            <installation_angle units="deg">0.0<!--Diameter of the propeller as a ratio of the wing chord behind the propeller--></installation_angle>
+            <material>0.0<!--1.0 for composite, 0.0 for aluminium--></material>
+            <number_blades>3.0<!--Number of blades on the propeller--></number_blades>
+            <rpm_mission units="1/min">2500.0</rpm_mission>
+            <solidity>0.13517604<!--Solidity of the propeller--></solidity>
+          </propeller_1>
+        </propeller>
+        <DC_cable_harness>
+          <harness_1>
+            <cable_temperature_mission units="degK">303.15</cable_temperature_mission>
+          </harness_1>
+        </DC_cable_harness>
+        <PMSM>
+          <motor_1>
+            <front_length_ratio is_input="True">0.25<!--Location of the PMSM CG as a ratio of the aircraft front length--></front_length_ratio>
+            <rpm_rating units="1/min" is_input="True">8000.0<!--Max voltage of the motor--></rpm_rating>
+            <voltage_caliber units="V" is_input="True">660.0<!--Max voltage of the motor--></voltage_caliber>
+          </motor_1>
+        </PMSM>
+        <inverter>
+          <inverter_1>
+            <efficiency_mission>0.98</efficiency_mission>
+            <junction_temperature_mission units="degK">288.15</junction_temperature_mission>
+            <current_ripple is_input="True">0.2<!--Amplitude of the current ripple as a percent of the current caliber--></current_ripple>
+            <front_length_ratio is_input="True">0.9<!--Location of the inverter CG as a ratio of the aircraft front length--></front_length_ratio>
+            <heat_sink_temperature_mission units="degK" is_input="True">288.15<!--Heat sink temperature of the inverter for the points--></heat_sink_temperature_mission>
+            <power_factor is_input="True">1.0</power_factor>
+            <switching_frequency_mission units="Hz" is_input="True">12000.0<!--Switching frequency of the inverter for the points--></switching_frequency_mission>
+            <voltage_ripple is_input="True">0.01<!--Amplitude of the voltage ripple the capacitor should be able to withstand, as a percent of voltage caliber--></voltage_ripple>
+            <control_card>
+              <mass units="kg" is_input="True">1.0<!--Weight of the control card, is generally constant, taken at 1 kg--></mass>
+            </control_card>
+            <diode>
+              <gate_voltage units="V" is_input="True">1.3</gate_voltage>
+            </diode>
+            <heat_sink>
+              <density units="kg/m**3" is_input="True">2700.0<!--Density of the heat sink core for the inverter, by default aluminium is assumed--></density>
+              <temperature_rating units="degK" is_input="True">373.15<!--Density of the coolant fluid--></temperature_rating>
+              <coolant>
+                <density units="kg/m**3" is_input="True">1082.0<!--Density of the coolant fluid--></density>
+                <dynamic_viscosity units="Pa*s" is_input="True">0.00487<!--Dynamic viscosity of the coolant fluid--></dynamic_viscosity>
+                <specific_heat_capacity units="J/degK/kg" is_input="True">3260.0<!--Specific heat capacity of the coolant fluid--></specific_heat_capacity>
+                <temperature_in_rating units="degK" is_input="True">323.15<!--Density of the coolant fluid--></temperature_in_rating>
+                <temperature_out_rating units="degK" is_input="True">353.15<!--Density of the coolant fluid--></temperature_out_rating>
+                <thermal_conductivity units="W/m/degK" is_input="True">0.402<!--Thermal conductivity of the coolant fluid--></thermal_conductivity>
+              </coolant>
+              <tube>
+                <density units="kg/m**3" is_input="True">8960.0<!--Density of the tube for the cooling of the inverter, by default copper is assumed--></density>
+                <thickness units="m" is_input="True">0.00125<!--Thickness of the tube for the cooling of the inverter--></thickness>
+              </tube>
+            </heat_sink>
+            <igbt>
+              <gate_voltage units="V" is_input="True">0.87</gate_voltage>
+            </igbt>
+            <capacitor>
+              <aspect_ratio>2.0</aspect_ratio>
+            </capacitor>
+            <inductor>
+              <air_gap units="mm">2.7</air_gap>
+              <inductance units="H" is_input="False">1.3612212793999764e-06<!--Inductance of the inductor--></inductance>
+            </inductor>
+            <tube>
+              <number_of_passes is_input="True">4.0<!--Number of passes in the heat sink (between 2 and 6 usually)--></number_of_passes>
+            </tube>
+            <properties>
+              <resistance_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">0.0033</diode>
+                <igbt units="1/degK" is_input="True">0.0041</igbt>
+              </resistance_temperature_scale_factor>
+              <voltage_temperature_scale_factor>
+                <diode units="1/degK" is_input="True">-0.0022</diode>
+                <igbt units="1/degK" is_input="True">-0.00105</igbt>
+              </voltage_temperature_scale_factor>
+            </properties>
+          </inverter_1>
+        </inverter>
+        <planetary_gear>
+          <planetary_gear_1>
+            <gear_ratio>1.0</gear_ratio>
+            <power_split units="percent">90.0</power_split>
+          </planetary_gear_1>
+        </planetary_gear>
+        <battery_pack>
+          <battery_pack_1>
+            <cell_temperature_mission units="degK" is_input="True">298.15<!--Cell temperature of the battery for the points--></cell_temperature_mission>
+            <cell_volume_fraction is_input="True">0.8<!--Cell volume fraction, represents the contribution to the battery volume of the cells--></cell_volume_fraction>
+            <cell_weight_fraction is_input="True">0.768<!--Cell weight fraction, represents the contribution to the battery mass of the cells--></cell_weight_fraction>
+            <min_safe_SOC units="percent" is_input="True">0.0<!--Minimum state-of-charge that the battery can have without degradation--></min_safe_SOC>
+            <number_modules>12.0<!--Minimum state-of-charge that the battery can have without degradation--></number_modules>
+            <module>
+              <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
+            </module>
+            <CG>
+              <y_ratio>0.5</y_ratio>
+            </CG>
+          </battery_pack_1>
+        </battery_pack>
+      </he_power_train>
+    </propulsion>
+    <aerodynamics>
+      <propeller>
+        <mach is_input="True">0.0<!--mach number used to compute the polar of the airfoil used in the propeller computation--></mach>
+        <reynolds is_input="True">1000000.0<!--reynolds number used to compute the polar of the airfoil used in the propeller computation--></reynolds>
+        <cruise_level>
+          <altitude units="m" is_input="False">2438.4<!--altitude at which the cruise level propeller efficiency map was computed--></altitude>
+          <efficiency is_input="False">[[0.08530005486124256, 0.16829301352015982, 0.19729632102474817, 0.19948091923407776, 0.1919462541607033, 0.18151990502361054, 0.17071828377276843, 0.16055835068023994, 0.1514977491952318, 0.14283249726987826, 0.13461462171811225, 0.12709638574602894, 0.12003000411430331, 0.11350478154756086, 0.10796382230441834, 0.10282339988923522, 0.097776536438269, 0.09183076775470722, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149, 0.09143595479751149], [0.21898409717137646, 0.40860062791900587, 0.46627979554573395, 0.47353799840204236, 0.46197538443722513, 0.44395677687579493, 0.4240786363668649, 0.4046711622026329, 0.38679220698271255, 0.3699759641037544, 0.35298941135115025, 0.33717552270609685, 0.3222396600355954, 0.30768374985559105, 0.2941909091689512, 0.2826241789156212, 0.2717196412424635, 0.2611171470407305, 0.24968947461043978, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758, 0.23641577812268758], [0.3221821674387253, 0.54705852614785, 0.6094073636176869, 0.6207928152748975, 0.6125811135953867, 0.5963887835661168, 0.5770310730547497, 0.5569800199499474, 0.5378755337393591, 0.5204922804408615, 0.5019162003192688, 0.4838034583336272, 0.46668566213460727, 0.4502992934226298, 0.4333917579715272, 0.41823641941567186, 0.40496247713128364, 0.39215375852322937, 0.3797062616388516, 0.3667018100857163, 0.34991710488525835, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749, 0.3414115422608749], [0.3840847534404945, 0.6163723279469772, 0.6816313277992596, 0.6977179055990025, 0.6946876738814904, 0.6832304234487679, 0.6678054537563645, 0.6507730155955819, 0.633471466687619, 0.6180174682694553, 0.6014636738692486, 0.5840687173943357, 0.5673989254129931, 0.5512673208418547, 0.5354907126735293, 0.5189214467882629, 0.5043710925937906, 0.4912194090519666, 0.47837308094399594, 0.46578383617303787, 0.4528986393692126, 0.4367931098904753, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894, 0.42384108388308894], [0.4162206845504372, 0.6447180480543131, 0.7135170076505943, 0.7355876092833685, 0.7383238439925945, 0.7321561969119317, 0.7214475048364544, 0.7084832815542957, 0.6944863326765549, 0.6815148523448301, 0.6677208605045626, 0.6526082187226498, 0.6375655318133149, 0.6227682413928755, 0.6084197705521291, 0.5935910882220362, 0.5788231168982322, 0.565638863525112, 0.5532535287577882, 0.5411682790067882, 0.5292177821320938, 0.516983782697819, 0.5023188236684182, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427, 0.48658927219915427], [0.4069859818949012, 0.6484424054652869, 0.7229776812708956, 0.751460555371571, 0.759973043525158, 0.7591136433974462, 0.7529751346725001, 0.7440554187834634, 0.7336824494099241, 0.7234821449485286, 0.7122773688030222, 0.6997743309620104, 0.6869201554758978, 0.6739700927993334, 0.6612173003670883, 0.6483048784607617, 0.6349219162681938, 0.622233350869981, 0.6103925901336436, 0.5990528623199329, 0.5879646260227047, 0.5769442973750399, 0.5656497083168188, 0.5525081844483241, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039, 0.5351831666155039], [0.3947191962156007, 0.6365944318761548, 0.7202659706653445, 0.7548847315587227, 0.7689894907419799, 0.7730034616768446, 0.771170566163189, 0.7659912585066122, 0.7590769282499837, 0.7515138373399238, 0.74276068665281, 0.7326710070730431, 0.7220380965921961, 0.7110340456352593, 0.699990715817601, 0.6888711738011027, 0.6772095445285499, 0.6656676309390444, 0.6546833775008339, 0.6441323728290667, 0.6338467617699817, 0.6237619702210907, 0.6137156549682009, 0.6034537111765756, 0.5918190142266423, 0.575022851066347, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107, 0.5733459757298107], [0.37064153384005905, 0.6215881980042637, 0.711150239324778, 0.7512916886191463, 0.7706039901994188, 0.7789740112273803, 0.7810703885488236, 0.7793150493167846, 0.7754764321313032, 0.7703918081206474, 0.7639289870626179, 0.7560087732505143, 0.7473820938032627, 0.738282542440783, 0.7289114612304615, 0.7193990282090695, 0.7094941378115631, 0.6992647342068092, 0.6893388780495783, 0.6796975040873476, 0.6703012018911672, 0.6610268470504826, 0.6518719626451218, 0.6427420288461364, 0.6334653452524432, 0.6232275001609469, 0.6103811245963924, 0.6036861163374001, 0.6036861163374001, 0.6036861163374001], [0.3549459268348402, 0.6019916951199231, 0.6977553222217443, 0.7439880801720442, 0.7679914676049849, 0.7802746527801914, 0.7857390157782621, 0.7870148735983472, 0.7859366670138092, 0.7831059571064102, 0.7786884236334871, 0.7727834250453334, 0.7659858818955847, 0.7585897018801246, 0.7507943921728022, 0.742749259157464, 0.7343721564942727, 0.7255565313751866, 0.7167064968026865, 0.7080570299514463, 0.6995321238438824, 0.691106653633415, 0.6827668089780798, 0.6744751776147121, 0.6661856211066182, 0.6578098842165556, 0.6487977889029929, 0.6382216448259804, 0.6280241546079525, 0.6280241546079525], [0.3240202709619619, 0.5805271356146239, 0.6832491490506619, 0.734743399347032, 0.7629922010757247, 0.7788244989155665, 0.7872722146120348, 0.79119030253486, 0.7924152171565334, 0.7916024986382685, 0.7890316189418384, 0.7849491522890222, 0.779782668763414, 0.7739140769019306, 0.7675653509203515, 0.7608471433395458, 0.7537952117070004, 0.7463499252428681, 0.738603278788942, 0.7308702107417007, 0.7232405630129382, 0.7156525895027663, 0.7080657977241661, 0.7005420445821557, 0.6930230902659031, 0.6854986187191139, 0.6778985410310467, 0.6699611850296374, 0.6610305809456005, 0.6476421164613491]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at cruise level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at cruise level are computed--></speed>
+          <thrust units="N" is_input="False">[163.447801591381, 456.8832398290857, 750.3186780667904, 1043.7541163044953, 1337.1895545421999, 1630.6249927799045, 1924.0604310176093, 2217.495869255314, 2510.9313074930187, 2804.3667457307233, 3097.802183968428, 3391.237622206133, 3684.6730604438376, 3978.108498681542, 4271.543936919247, 4564.979375156951, 4858.414813394656, 5151.8502516323615, 5445.285689870066, 5738.721128107771, 6032.156566345475, 6325.59200458318, 6619.027442820885, 6912.462881058589, 7205.898319296294, 7499.333757533999, 7792.769195771703, 8086.204634009408, 8379.640072247113, 8673.075510484818]<!--thrust produced by the propeller at cruise level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[5166.687446702883, 5683.084379455381, 6104.941620936745, 6472.966495514782, 6819.855775185387, 7161.545168399918, 7508.616995426542, 7868.808840383192, 8254.67947404465, 8673.075510484818]<!--maximum thrust output of the propeller at cruise level for varying velocities--></thrust_limit>
+        </cruise_level>
+        <sea_level>
+          <efficiency is_input="False">[[0.08559524652103005, 0.16746079374777373, 0.19700334637165667, 0.1997708841011615, 0.19266563931119182, 0.18249945813876728, 0.17187221081889678, 0.16179598598205108, 0.15279191802180817, 0.14420689755285862, 0.1359887975944682, 0.1284682176722167, 0.12142752525910311, 0.11482058873387413, 0.10922456578374536, 0.10409393339502468, 0.09909897012707508, 0.09354611420669316, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878, 0.09175067594167878], [0.21946683955857027, 0.4070653813646662, 0.4656512860894166, 0.4738513549980477, 0.4631998668180335, 0.4457605310821373, 0.42627268655372336, 0.40711600630357425, 0.3893980713967947, 0.3728107754376203, 0.35593852900489553, 0.3401588885590199, 0.32527598717498685, 0.31080232316423495, 0.29716167335245053, 0.28550448609430107, 0.27462422109232054, 0.2641024291551355, 0.2530944970363329, 0.23751757158728953, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416, 0.2371604494261416], [0.32295240661343527, 0.545587317977352, 0.6086955644209024, 0.621073801322977, 0.6137032720618116, 0.5981852023617394, 0.5793226760693, 0.5596245367201715, 0.5407400664411743, 0.5236415832816252, 0.5053182919871878, 0.487307499402436, 0.4702535847438607, 0.4540024280022737, 0.43725452406498266, 0.42187298218113917, 0.4085683837175746, 0.3958226535019926, 0.3834550018470688, 0.37083713946439095, 0.35511571212452414, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085, 0.34243070856167085], [0.38485662650771013, 0.6149284281262366, 0.680928584926233, 0.6979238400830844, 0.6956546136037444, 0.6848044854741254, 0.6698590343459225, 0.6532081849326775, 0.6361431536072055, 0.6210239535985712, 0.6047878596596149, 0.5875558772862273, 0.5710068630367056, 0.5549738893472026, 0.5393703187482276, 0.5229040328056744, 0.5082299514539513, 0.4950863361961832, 0.4823301053823931, 0.4698387692922264, 0.4572267778273543, 0.4419975160654984, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031, 0.4251255927706031], [0.41646514016979747, 0.6434352427283466, 0.7128217474307318, 0.7356950909690921, 0.7390073188405037, 0.7334254787546669, 0.7231912616629405, 0.7106049759583282, 0.6969631753296891, 0.6842245814347332, 0.6707300634702648, 0.6558518245385779, 0.6409675406536163, 0.6263010174428982, 0.6120891019859229, 0.5974565305343131, 0.5826787040317936, 0.5694960837894123, 0.5571698893121968, 0.5451634650356759, 0.5333257323912791, 0.5212968187573547, 0.5073397562276435, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998, 0.4880812099118998], [0.409455378135157, 0.6473345846622222, 0.7223147863600431, 0.7514764752690146, 0.7605036797131038, 0.7601721845258685, 0.7544204997326877, 0.7458851729668731, 0.7358617896966939, 0.7259313436535808, 0.7149986021712363, 0.7026942311022902, 0.6900289608728961, 0.6772297533647824, 0.6646183122217576, 0.6518790959788052, 0.6385848136034126, 0.6259679819780883, 0.6141778123645895, 0.6029121762392661, 0.5919030780374738, 0.5809818952622033, 0.5698720398613432, 0.557217324025475, 0.5372944491852183, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414, 0.53685961698414], [0.3953312638004441, 0.6358115370524278, 0.7196996332074858, 0.7548432086869586, 0.7694092269011428, 0.773832881644416, 0.7724242657122274, 0.7675665995019243, 0.7610074890956313, 0.7537129129619586, 0.7451907098452001, 0.7353012807651571, 0.7248475866981763, 0.714015272638944, 0.7031205982212984, 0.692145975087162, 0.6806184723781162, 0.6691779531618413, 0.658279803844729, 0.6478016191218834, 0.637599039386411, 0.6275947375293485, 0.6176408964767897, 0.6075142201040424, 0.5962206004520426, 0.5813318776712864, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875, 0.5752140028123875], [0.37502214790548005, 0.621513702458121, 0.7106598336732024, 0.7512486934842537, 0.7709687399998211, 0.7797129768048593, 0.7821466237893939, 0.7807195992387596, 0.777239236257852, 0.7724066683263304, 0.7661288703458095, 0.7584143086559684, 0.7499418418991161, 0.7410174056290642, 0.7318034765974706, 0.7224233087124184, 0.7126289298037244, 0.7025142675967138, 0.6927099445099428, 0.6831584952387556, 0.6738623108724029, 0.6646719000901224, 0.6556001557389005, 0.6465481583464296, 0.6373780578932061, 0.6273363973051153, 0.6150016987364886, 0.6057495835080302, 0.6057495835080302, 0.6057495835080302], [0.35508508960321633, 0.601405382049293, 0.6973966914478564, 0.7439989072630241, 0.7683660336108185, 0.7809881021710351, 0.7867626680387921, 0.7883464328502263, 0.7875783300712109, 0.7850084714489851, 0.7807432930120342, 0.7750217914073025, 0.7683659693251536, 0.7611277284841014, 0.7534858390350037, 0.7455796856748332, 0.7373097504283624, 0.728602057524929, 0.7198716458340264, 0.7113281930517014, 0.702903445541824, 0.6945660765205901, 0.6863239840190664, 0.6781044656160994, 0.6698991214263045, 0.6615946458117216, 0.6526938773741703, 0.6422847359663604, 0.6303181609714937, 0.6303181609714937], [0.32688741261648224, 0.5804727423083644, 0.6831129180397443, 0.7348673233187948, 0.7634321345443952, 0.7795721244454902, 0.7882882658060564, 0.7925302028986236, 0.794015043273824, 0.7934572457863657, 0.7909915389033304, 0.7870631908251293, 0.7820364066960803, 0.776325135869199, 0.770123944795257, 0.7635379460083411, 0.756583439306165, 0.7492190954094681, 0.7415941988825705, 0.7339711052029734, 0.7264464102959793, 0.7189606778007763, 0.7114646261817927, 0.7040172063029317, 0.6965813695746137, 0.6891321045957475, 0.6815952960622204, 0.67369851983467, 0.6648170015283738, 0.6502311380843497]]<!--2D matrix containing the efficiencies of the propeller in different speed conditions and for different thrust requirement at sea level--></efficiency>
+          <speed units="m/s" is_input="False">[5.0, 15.41925925925926, 25.83851851851852, 36.257777777777775, 46.67703703703704, 57.0962962962963, 67.51555555555555, 77.93481481481481, 88.35407407407408, 98.77333333333334]<!--speed at which the efficiencies of the propeller at sea level are computed--></speed>
+          <thrust units="N" is_input="False">[208.48223431412015, 575.2513628160312, 942.0204913179423, 1308.7896198198534, 1675.5587483217646, 2042.3278768236758, 2409.0970053255865, 2775.866133827498, 3142.6352623294088, 3509.4043908313197, 3876.173519333231, 4242.942647835142, 4609.711776337053, 4976.480904838964, 5343.250033340876, 5710.019161842787, 6076.788290344698, 6443.557418846609, 6810.32654734852, 7177.095675850432, 7543.864804352343, 7910.6339328542535, 8277.403061356164, 8644.172189858076, 9010.941318359986, 9377.710446861898, 9744.479575363808, 10111.24870386572, 10478.017832367632, 10844.786960869542]<!--thrust produced by the propeller at sea level and for which the efficiencies are given--></thrust>
+          <thrust_limit units="N" is_input="False">[6533.840174009261, 7181.649624427429, 7704.744804457652, 8163.379307607336, 8591.84017293703, 9012.766951506735, 9435.643628430062, 9874.443915635982, 10339.44635971018, 10844.786960869542]<!--maximum thrust output of the propeller at sea level for varying velocities--></thrust_limit>
+        </sea_level>
+      </propeller>
+    </aerodynamics>
+    <handling_qualities>
+      <static_margin>
+        <target>0.15<!--static margin we want to achieve--></target>
+      </static_margin>
+    </handling_qualities>
+    <mission>
+      <sizing>
+        <initial_climb>
+          <energy units="W*h">0.0</energy>
+          <fuel units="kg">0.08855397685162596</fuel>
+        </initial_climb>
+        <landing>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during landing--></elevator_angle>
+          <flap_angle units="deg">30.0<!--position of the flaps during landing--></flap_angle>
+          <target_sideslip units="deg">15.0</target_sideslip>
+        </landing>
+        <takeoff>
+          <elevator_angle units="deg">-25.0<!--position of the elevator during takeoff--></elevator_angle>
+          <energy units="W*h">0.0</energy>
+          <flap_angle units="deg">10.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
+          <fuel units="kg">0.4560783599663149</fuel>
+          <thrust_rate>1.0<!--thrust rate during takeoff phase--></thrust_rate>
+        </takeoff>
+        <taxi_in>
+          <duration units="s">300.0<!--duration of taxi-in phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-in phase in sizing mission--></speed>
+        </taxi_in>
+        <taxi_out>
+          <duration units="s">300.0<!--duration of taxi-out phase in sizing mission--></duration>
+          <speed units="kn">20.0<!--speed during taxi-out phase in sizing mission--></speed>
+        </taxi_out>
+        <cs23>
+          <characteristic_speed>
+            <vd units="kn">202.6<!--limit speed--></vd>
+          </characteristic_speed>
+          <sizing_factor>
+            <ultimate_aircraft>5.7<!--ultimate load factor that the aircraft will experience (default value is 5.7)--></ultimate_aircraft>
+          </sizing_factor>
+        </cs23>
+        <main_route>
+          <cruise>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
+          </cruise>
+          <descent>
+            <descent_rate units="ft/min">-500.0<!--target descent rate for the aircraft--></descent_rate>
+          </descent>
+          <reserve>
+            <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
+            <duration units="min">45.0<!--duration of the reserve segment--></duration>
+          </reserve>
+          <climb>
+            <climb_rate>
+              <cruise_level units="ft/min">790.0<!--target climb rate at the end of climb--></cruise_level>
+              <sea_level units="ft/min">1270.0<!--target climb rate at sea level--></sea_level>
+            </climb_rate>
+          </climb>
+        </main_route>
+      </sizing>
+    </mission>
+    <weight>
+      <airframe>
+        <fuselage>
+          <k_factor>1.0<!--proportional corrective factor for fuselage mass--></k_factor>
+        </fuselage>
+        <horizontal_tail>
+          <k_factor>1.0<!--proportional corrective factor for horizontal tail mass--></k_factor>
+        </horizontal_tail>
+        <paint>
+          <mass units="lbm">1.0<!--Mass of the airframe_inp_data:weight:airframe:paint:mass--></mass>
+        </paint>
+        <vertical_tail>
+          <k_factor>1.0<!--proportional corrective factor for vertical tail mass--></k_factor>
+        </vertical_tail>
+        <wing>
+          <k_factor>0.9<!--proportional corrective factor for wing mass--></k_factor>
+        </wing>
+      </airframe>
+      <propulsion>
+        <engine>
+          <mass units="lbm">731.6708415039819<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
+        </engine>
+        <fuel_lines>
+          <mass units="lbm">71.48274780115939<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
+        </fuel_lines>
+        <unusable_fuel>
+          <mass units="lbm">0.0<!--total unusable fuel mass--></mass>
+        </unusable_fuel>
+      </propulsion>
+      <systems>
+        <power>
+          <electric_systems>
+            <mass units="lbm">189.12923759516593<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="lbm">25.5648480458697<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+  </data>
+  <settings>
+    <handling_qualities>
+      <rudder>
+        <safety_margin>0.2<!--Ratio of the total rudder deflection not used in the computation of the VT area to leave a safety margin--></safety_margin>
+      </rudder>
+    </handling_qualities>
+    <propulsion>
+      <IC_engine>
+        <k_factor_sfc>1.0<!--k_factor that can be used to adjust the consumption on engine level to the aircraft level--></k_factor_sfc>
+      </IC_engine>
+      <he_power_train>
+        <ICE>
+          <ice_1>
+            <cg_in_nacelle>0.9<!--Location of the engine CG in the nacelle, in percent of the nacelle length--></cg_in_nacelle>
+            <k_sfc>1.0<!--K-factor to adjust the sfc of the ICE--></k_sfc>
+          </ice_1>
+        </ICE>
+        <PMSM>
+          <motor_1>
+            <k_efficiency is_input="True">0.971<!--K factor for the PMSM efficiency--></k_efficiency>
+            <power_factor is_input="True">1.0</power_factor>
+          </motor_1>
+        </PMSM>
+      </he_power_train>
+    </propulsion>
+    <weight>
+      <aircraft>
+        <CG>
+          <range>0.217<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg">80.0<!--design payload mass carried by passenger--></design_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <landing_gear>
+          <front>
+            <weight_ratio>0.13<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+          </front>
+        </landing_gear>
+      </airframe>
+      <propulsion>
+        <tank>
+          <CG>
+            <from_wingMAC25>0.25<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
+          </CG>
+        </tank>
+      </propulsion>
+    </weight>
+    <mission>
+      <sizing>
+        <main_route>
+          <reserve>
+            <speed>
+              <k_factor is_input="True">2.2<!--Ration between the speed during the reserve segment and stall speed--></k_factor>
+            </speed>
+          </reserve>
+        </main_route>
+      </sizing>
+    </mission>
+  </settings>
+</FASTOAD_model>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -385,7 +385,7 @@
         <planetary_gear>
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
-            <power_share units="kW">180.0</power_share>
+            <power_share units="kW">160.0</power_share>
             <power_split units="percent">90.0</power_split>
           </planetary_gear_1>
         </planetary_gear>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -296,10 +296,7 @@
             <number_modules>20</number_modules>
             <CG>
               <y_ratio>0.5</y_ratio>
-            </CG>
-            <cell>
-              <c_rate_caliber units="min**-1">8.0</c_rate_caliber>
-            </cell>
+            </CG>>
             <module>
               <number_cells is_input="True">150.0<!--Number of cells in series inside one battery module--></number_cells>
             </module>

--- a/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
+++ b/integration_tests/cirrus_sr22/data/input_sr22_hybrid.xml
@@ -385,7 +385,7 @@
         <planetary_gear>
           <planetary_gear_1>
             <gear_ratio>1.0</gear_ratio>
-            <power_share units="kW" is_input="True">161.8421052631579<!--Share of the power going to the first (primary) input, in W--></power_share>
+            <power_share units="kW" is_input="True">150.<!--Share of the power going to the first (primary) input, in W--></power_share>
             <power_split units="percent">90.0</power_split>
           </planetary_gear_1>
         </planetary_gear>
@@ -472,6 +472,7 @@
           <reserve>
             <altitude units="ft">8000.0<!--altitude during cruise phase in sizing mission--></altitude>
             <duration units="min">45.0<!--duration of the reserve segment--></duration>
+            <v_tas units="m/s" is_input="True">81.50524966609954</v_tas>
           </reserve>
           <climb>
             <climb_rate>

--- a/integration_tests/cirrus_sr22/data/op_mission_electric.yml
+++ b/integration_tests/cirrus_sr22/data/op_mission_electric.yml
@@ -1,0 +1,32 @@
+title: Payload range drawing for thermal version of the aircraft
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/op_mission_elec_in.xml
+output_file: ../results/op_mission_elec_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
+
+model:
+  performances:
+    id: fastga_he.performances.op_mission_target_SoC
+    number_of_points_climb: 30
+    number_of_points_cruise: 30
+    number_of_points_descent: 20
+    number_of_points_reserve: 10
+    power_train_file_path: ./electric_propulsion_two_motors.yml
+    use_linesearch: False
+    pre_condition_pt: True
+    use_apply_nonlinear: True
+    variable_name_target_SoC: data__propulsion__he_power_train__battery_pack__battery_pack_1__SOC_min
+
+submodels:
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.ensure
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null

--- a/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
+++ b/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
@@ -23,6 +23,9 @@ model:
         use_linesearch: False
         pre_condition_pt: False
         use_apply_nonlinear: False
+    environmental_impact:
+        id: fastga_he.environmental.energy_simple
+        mission: operational
 
 submodels:
     submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.ensure

--- a/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
+++ b/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
@@ -35,4 +35,5 @@ submodels:
     service.geometry.nacelle.dimension: null
     service.geometry.vertical_tail.distance.fd: null
     service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+    submodel.performances.mission_vector.reserve_speed: null
 

--- a/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
+++ b/integration_tests/cirrus_sr22/data/op_mission_fuel.yml
@@ -1,0 +1,35 @@
+title: Sample operational mission computation applied to TBM 900
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+
+# Input and output files
+input_file: ../results/op_mission_in_fuel.xml
+output_file: ../results/op_mission_out_fuel.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
+
+model:
+    performances:
+        id: fastga_he.performances.operational_mission_vector
+        number_of_points_climb: 30
+        number_of_points_cruise: 30
+        number_of_points_descent: 20
+        number_of_points_reserve: 10
+        power_train_file_path: ./fuel_propulsion.yml
+        out_file: ../results/fuel_propulsion_op_mission.csv
+        use_linesearch: False
+        pre_condition_pt: False
+        use_apply_nonlinear: False
+
+submodels:
+    submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.ensure
+    submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+    service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
+    service.weight.mass.system.power_system: null
+    service.geometry.nacelle.dimension: null
+    service.geometry.vertical_tail.distance.fd: null
+    service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+

--- a/integration_tests/cirrus_sr22/data/op_mission_hybrid.yml
+++ b/integration_tests/cirrus_sr22/data/op_mission_hybrid.yml
@@ -1,0 +1,42 @@
+title: Sample operational mission computation applied to TBM 900
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+
+# Input and output files
+input_file: ../results_better_cells/op_mission_in_hybrid.xml
+output_file: ../results_better_cells/op_mission_out_hybrid.xml
+
+model:
+    performances:
+        id: fastga_he.performances.operational_mission_vector
+        number_of_points_climb: 30
+        number_of_points_cruise: 30
+        number_of_points_descent: 20
+        number_of_points_reserve: 10
+        power_train_file_path: ./hybrid_propulsion.yml
+        out_file: ../results_better_cells/fuel_propulsion_op_mission.csv
+        use_linesearch: False
+        pre_condition_pt: False
+        use_apply_nonlinear: False
+    environmental_impact:
+        id: fastga_he.environmental.energy_simple
+        mission: operational
+
+submodels:
+    submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.ensure
+    submodel.weight.cg.aircraft_empty.x: fastga_he.submodel.weight.cg.aircraft_empty.x.with_propulsion_as_one
+    submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+    submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+    submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+    submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+    submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+    submodel.propulsion.dc_dc_converter.inductor.inductance: null
+    service.weight.mass.systems: fastga.submodel.weight.mass.systems.legacy
+    service.weight.mass.system.power_system: null
+    service.geometry.nacelle.dimension: null
+    service.geometry.vertical_tail.distance.fd: null
+    service.geometry.fuselage.wet_area: fastga.submodel.geometry.fuselage.wet_area.flops
+    submodel.performances.mission_vector.reserve_speed: null
+

--- a/integration_tests/cirrus_sr22/data/payload_range_electric.yml
+++ b/integration_tests/cirrus_sr22/data/payload_range_electric.yml
@@ -1,0 +1,24 @@
+title: Payload range drawing for thermal version of the aircraft
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/payload_range_elec_in.xml
+output_file: ../results/payload_range_elec_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
+
+model:
+  outer_payload_range:
+    id: fastga_he.payload_range.outer
+    power_train_file_path: ./electric_propulsion_two_motors.yml
+
+submodels:
+  submodel.propulsion.constraints.pmsm.rpm: fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure
+  submodel.propulsion.constraints.pmsm.torque: fastga_he.submodel.propulsion.constraints.pmsm.torque.enforce
+  submodel.propulsion.constraints.inverter.current: fastga_he.submodel.propulsion.constraints.inverter.current.enforce
+  submodel.propulsion.constraints.battery.state_of_charge: fastga_he.submodel.propulsion.constraints.battery.state_of_charge.enforce
+  submodel.propulsion.constraints.inductor.air_gap: fastga_he.submodel.propulsion.constraints.inductor.air_gap.enforce
+  submodel.propulsion.dc_dc_converter.inductor.inductance: null

--- a/integration_tests/cirrus_sr22/data/payload_range_thermal.yml
+++ b/integration_tests/cirrus_sr22/data/payload_range_thermal.yml
@@ -1,0 +1,19 @@
+title: Payload range drawing for thermal version of the aircraft
+
+# List of folder paths where user added custom registered OpenMDAO components
+module_folders:
+
+# Input and output files
+input_file: ../results/payload_range_thermal_in.xml
+output_file: ../results/payload_range_thermal_out.xml
+
+# Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
+
+model:
+  outer_payload_range:
+    id: fastga_he.payload_range.outer
+    power_train_file_path: ./fuel_propulsion.yml
+
+submodels:
+  submodel.propulsion.constraints.ice.sea_level_power: fastga_he.submodel.propulsion.constraints.ice.sea_level_power.ensure

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -24,7 +24,7 @@ def cleanup():
     rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
 
 
-def test_sizing_sr22(cleanup):
+def test_sizing_sr22():
     # TODO: Check why he needs the propulsion data as inputs
     # ANS: still used for the Z_cg of the aircraft which is assumed to have only a minor influence
 
@@ -67,8 +67,12 @@ def test_sizing_sr22(cleanup):
     )
 
 
-def test_sizing_sr22_electric(cleanup):
-    """Test the overall aircraft design process with wing positioning under VLM method."""
+def test_sizing_sr22_electric_original():
+    """
+    Tests an electric sr22 with the same climb, cruise, descent and reserve profile as the original
+    one but a range of 100 nm. The only change is the ratio between stall speed and reserve speed
+    which is set at 1.3 (ratio between approach and stall)
+    """
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
     logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
@@ -97,8 +101,3 @@ def test_sizing_sr22_electric(cleanup):
     residuals = filter_residuals(residuals)
 
     problem.write_outputs()
-
-    assert problem.get_val("data:weight:aircraft:MTOW", units="kg") == pytest.approx(
-        1601.0, rel=1e-2
-    )
-    assert problem.get_val("data:weight:aircraft:OWE", units="kg") == pytest.approx(992.0, rel=1e-2)

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -92,7 +92,6 @@ def test_sizing_sr22_op_mission():
     problem.setup()
 
     problem.set_val("data:mission:operational:range", val=200, units="NM")
-    problem.set_val("settings:operational:reserve:speed:k_factor", val=2.2)
 
     # om.n2(problem, show_browser=False, outfile=n2_path)
 
@@ -604,7 +603,7 @@ def test_doe_sr22_hybrid_power_share():
         units="h**-1",
     )
 
-    power_shares = np.linspace(160, 195, 20)
+    power_shares = np.linspace(140, 160, 11)
 
     for power_share in power_shares:
         problem.set_val(
@@ -698,6 +697,7 @@ def rename_variables_for_payload_range(source_file_path: pathlib.Path):
         "data:mission:operational:taxi_in:speed": "data:mission:sizing:taxi_in:speed",
         "data:mission:operational:taxi_out:duration": "data:mission:sizing:taxi_out:duration",
         "data:mission:operational:taxi_out:speed": "data:mission:sizing:taxi_out:speed",
+        "data:mission:operational:reserve:v_tas": "data:mission:sizing:main_route:reserve:v_tas",
     }
 
     datafile = oad.DataFile(source_file_path)

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -817,15 +817,20 @@ def test_sizing_sr22_hybrid_no_lto_improved():
     smoothing_zone_width = 17
     smoothing_zone_width_descent = min(smoothing_zone_width, 12)  # To avoid going into cruise
     smoothing_zone_width_climb = min(smoothing_zone_width, 22)  # To avoid going into cruise
-    power_split = 100.0 * np.concatenate(
-        (
-            np.zeros(12),  # Taxi out and climb
-            np.linspace(0, 1, smoothing_zone_width_climb + 2)[1:-1],  # Transition
-            np.ones(61 - smoothing_zone_width_descent - smoothing_zone_width_climb),  # End of climb, cruise and start of descent
-            np.linspace(1, 0, smoothing_zone_width_descent + 2)[1:-1],  # Transition
-            np.zeros(8),  # End of descent
-            np.ones(10),  # Reserve
-            np.zeros(1),  # Taxi in
+    power_split = (
+        100.0
+        * np.concatenate(
+            (
+                np.zeros(12),  # Taxi out and climb
+                np.linspace(0, 1, smoothing_zone_width_climb + 2)[1:-1],  # Transition
+                np.ones(
+                    61 - smoothing_zone_width_descent - smoothing_zone_width_climb
+                ),  # End of climb, cruise and start of descent
+                np.linspace(1, 0, smoothing_zone_width_descent + 2)[1:-1],  # Transition
+                np.zeros(8),  # End of descent
+                np.ones(10),  # Reserve
+                np.zeros(1),  # Taxi in
+            )
         )
     )
     datafile = oad.DataFile(problem.input_file_path)
@@ -881,8 +886,12 @@ def test_sizing_sr22_hybrid_no_lto_improved():
     mission_file = pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion.csv")
     mission_file.rename(RESULTS_FOLDER_PATH / "hybrid_propulsion_no_LTO_improved.csv")
 
-    if pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv").exists():
-        pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv").unlink()
+    if pathlib.Path(
+        RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv"
+    ).exists():
+        pathlib.Path(
+            RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv"
+        ).unlink()
     pt_watcher_file = pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher.csv")
     pt_watcher_file.rename(RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv")
 

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -476,6 +476,9 @@ def test_sizing_sr22_hybrid():
 
     problem.write_needed_inputs(ref_inputs)
     problem.read_inputs()
+
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": True}
+
     problem.setup()
 
     # om.n2(problem, show_browser=False, outfile=n2_path)
@@ -505,30 +508,20 @@ def test_doe_sr22_hybrid_power_split():
 
     power_splits = np.linspace(80, 95, 16)
 
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    # Model options are set up straight into the configuration file
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": True}
+    problem.setup()
+
     for power_split in power_splits:
-        configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
-        problem = configurator.get_problem()
-
-        # Create inputs
-        ref_inputs = DATA_FOLDER_PATH / xml_file_name
-        # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
-
-        # Model options are set up straight into the configuration file
-        problem.write_needed_inputs(ref_inputs)
-        problem.read_inputs()
-        problem.setup()
-
-        # The electric motor model is very sensitive to the rated rpm of the chassis unfortunately,
-        # especially in this tests where rated power for the motor can vary between 10 and 80 kW
-        # resulting in, when looking at the reference motor family, rated rpm ranging from 6500 to
-        # 4000. So to increase confidence in the results and based on a first try, we'll set the
-        # rated rpm as a function of the hybridization ratio
-        expected_power = -3.6064 * power_split + 354.82
-        expected_rpm = np.clip(0.0864 * expected_power ** 2 - 43.22 * expected_power + 7686.8, 3250, 6500)
-
-        problem.set_val(
-            "data:propulsion:he_power_train:PMSM:motor_1:rpm_rating", val=expected_rpm, units="min**-1"
-        )
 
         problem.set_val(
             "data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split",

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -67,6 +67,7 @@ def test_sizing_sr22():
         234.00, rel=1e-2
     )
 
+
 def test_sizing_sr22_op_mission():
     """Test the overall aircraft design process with wing positioning under VLM method."""
     logging.basicConfig(level=logging.WARNING)
@@ -89,6 +90,7 @@ def test_sizing_sr22_op_mission():
     problem.setup()
 
     problem.set_val("data:mission:operational:range", val=200, units="NM")
+    problem.set_val("settings:operational:reserve:speed:k_factor", val=2.2)
 
     # om.n2(problem, show_browser=False, outfile=n2_path)
 

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -663,6 +663,7 @@ def test_sizing_sr22_hybrid_power_share():
         "reference_curve_current": [500, 5000, 10000, 15000, 20000],
         "reference_curve_relative_capacity": [1.0, 0.97, 1.0, 0.97, 0.95],
     }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": True}
 
     problem.setup()
 
@@ -721,6 +722,7 @@ def test_doe_sr22_hybrid_power_share():
         "reference_curve_current": [500, 5000, 10000, 15000, 20000],
         "reference_curve_relative_capacity": [1.0, 0.97, 1.0, 0.97, 0.95],
     }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": True}
 
     problem.setup()
 
@@ -739,7 +741,8 @@ def test_doe_sr22_hybrid_power_share():
         units="h**-1",
     )
 
-    power_shares = np.linspace(140, 160, 11)
+    # power_shares = np.linspace(150, 190, 18)
+    power_shares = np.linspace(154.7059, 157.0588, 5)[1:-1]
 
     for power_share in power_shares:
         problem.set_val(
@@ -793,6 +796,7 @@ def test_optimization_sr22_hybrid_power_share():
         "reference_curve_current": [500, 5000, 10000, 15000, 20000],
         "reference_curve_relative_capacity": [1.0, 0.97, 1.0, 0.97, 0.95],
     }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": True}
 
     problem.setup()
 
@@ -866,6 +870,7 @@ def test_sizing_sr22_hybrid_no_lto():
         "reference_curve_current": [500, 5000, 10000, 15000, 20000],
         "reference_curve_relative_capacity": [1.0, 0.97, 1.0, 0.97, 0.95],
     }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": False}
 
     problem.setup()
 
@@ -873,7 +878,9 @@ def test_sizing_sr22_hybrid_no_lto():
     problem.model.nonlinear_solver.options["aitken_max_factor"] = 0.8
     problem.model.nonlinear_solver.options["aitken_min_factor"] = 0.33
     problem.model.nonlinear_solver.options["aitken_initial_factor"] = 0.8
-    problem.model.nonlinear_solver.options["maxiter"] = 20
+    problem.model.nonlinear_solver.options["maxiter"] = 30
+    problem.model.nonlinear_solver.options["stall_limit"] = 5
+    problem.model.nonlinear_solver.options["stall_tol"] = 3e-6
 
     # We will need the biggest motor we can get, the EMRAX348
     problem.set_val(
@@ -967,6 +974,7 @@ def test_sizing_sr22_hybrid_no_lto_improved():
         "reference_curve_current": [500, 5000, 10000, 15000, 20000],
         "reference_curve_relative_capacity": [1.0, 0.97, 1.0, 0.97, 0.95],
     }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": False}
 
     problem.setup()
 
@@ -974,7 +982,9 @@ def test_sizing_sr22_hybrid_no_lto_improved():
     problem.model.nonlinear_solver.options["aitken_max_factor"] = 0.8
     problem.model.nonlinear_solver.options["aitken_min_factor"] = 0.33
     problem.model.nonlinear_solver.options["aitken_initial_factor"] = 0.8
-    problem.model.nonlinear_solver.options["maxiter"] = 20
+    problem.model.nonlinear_solver.options["maxiter"] = 30
+    problem.model.nonlinear_solver.options["stall_limit"] = 5
+    problem.model.nonlinear_solver.options["stall_tol"] = 3e-6
 
     # We will need the biggest motor we can get, the EMRAX348
     problem.set_val(

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -67,6 +67,35 @@ def test_sizing_sr22():
         234.00, rel=1e-2
     )
 
+def test_sizing_sr22_op_mission():
+    """Test the overall aircraft design process with wing positioning under VLM method."""
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "full_sizing_out.xml"
+    process_file_name = "op_mission_fuel.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = RESULTS_FOLDER_PATH / xml_file_name
+    rename_variables_for_payload_range(ref_inputs)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    problem.set_val("data:mission:operational:range", val=200, units="NM")
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    problem.write_outputs()
+
 
 def test_sizing_sr22_electric_original():
     """
@@ -409,9 +438,7 @@ def test_payload_range_comparison():
 def test_sizing_sr22_hybrid():
     """
     Tests a hybrid sr22 with the same climb, cruise, descent and reserve profile as the original
-    one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights). The only change is
-    the ratio between stall speed and reserve speed which is set at 1.3 (ratio between approach
-    and stall)
+    one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights).
     """
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("fastoad.module_management._bundle_loader").disabled = True

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -65,3 +65,40 @@ def test_sizing_sr22(cleanup):
     assert problem.get_val("data:mission:sizing:fuel", units="kg") == pytest.approx(
         234.00, rel=1e-2
     )
+
+
+def test_sizing_sr22_electric(cleanup):
+    """Test the overall aircraft design process with wing positioning under VLM method."""
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_electric.xml"
+    process_file_name = "full_sizing_electric.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, process_file_name))
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = pth.join(DATA_FOLDER_PATH, xml_file_name)
+    # n2_path = pth.join(RESULTS_FOLDER_PATH, "n2_cirrus.html")
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.write_outputs()
+
+    assert problem.get_val("data:weight:aircraft:MTOW", units="kg") == pytest.approx(
+        1601.0, rel=1e-2
+    )
+    assert problem.get_val("data:weight:aircraft:OWE", units="kg") == pytest.approx(992.0, rel=1e-2)

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -2,7 +2,7 @@
 # Electric Aircraft.
 # Copyright (C) 2022 ISAE-SUPAERO
 
-import os.path as pth
+import pathlib
 from shutil import rmtree
 import logging
 
@@ -12,9 +12,9 @@ import fastoad.api as oad
 
 from utils.filter_residuals import filter_residuals
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
-WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")
+DATA_FOLDER_PATH = pathlib.Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results"
+WORKDIR_FOLDER_PATH = pathlib.Path(__file__).parent / "workdir"
 
 
 @pytest.fixture(scope="module")
@@ -37,11 +37,11 @@ def test_sizing_sr22():
     xml_file_name = "input_sr22.xml"
     process_file_name = "full_sizing_fuel.yml"
 
-    configurator = oad.FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, process_file_name))
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
     problem = configurator.get_problem()
 
     # Create inputs
-    ref_inputs = pth.join(DATA_FOLDER_PATH, xml_file_name)
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
     # n2_path = pth.join(RESULTS_FOLDER_PATH, "n2_cirrus.html")
     # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
 
@@ -81,12 +81,11 @@ def test_sizing_sr22_electric_original():
     xml_file_name = "input_sr22_electric.xml"
     process_file_name = "full_sizing_electric.yml"
 
-    configurator = oad.FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, process_file_name))
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
     problem = configurator.get_problem()
 
     # Create inputs
-    ref_inputs = pth.join(DATA_FOLDER_PATH, xml_file_name)
-    # n2_path = pth.join(RESULTS_FOLDER_PATH, "n2_cirrus.html")
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
     # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
 
     problem.write_needed_inputs(ref_inputs)
@@ -101,3 +100,172 @@ def test_sizing_sr22_electric_original():
     residuals = filter_residuals(residuals)
 
     problem.write_outputs()
+
+
+def test_sizing_sr22_electric_two_motors():
+    """
+    Same tests as above except, to increase confidence in e-motor results we will take two "stacked"
+    motors instead of a big one, as is doable with EMRAX engine. They will be coupled by a gearbox
+    of 0 kg and 0.99 efficiency. Also, because the E-motor doesn't lose power with altitude, the
+    climb rate at cruise level will be improved which should result in better energy efficiency.
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_electric_two_motors.xml"
+    process_file_name = "full_sizing_electric_two_motors.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.write_outputs()
+
+    assert problem.get_val("data:weight:aircraft:MTOW", units="kg") == pytest.approx(
+        3172.0, rel=1e-2
+    )
+    assert problem.get_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:mass", units="kg"
+    ) == pytest.approx(745.0, abs=1e-2)
+
+
+def test_sizing_sr22_electric_two_motors_improved_range_sensitivity():
+    """
+    Same tests as above except we test some possible improvements:
+    - Not certify the aircraft under IFR but rather VFR, in our context it means a reserve of 30
+        min instead of 45 min
+    - Keep decreasing the range to 50 nm (only 23% of flights) (not worth not done) but instead
+        we'll look at the evolution of MTOW and battery mass with range
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_electric_two_motors.xml"
+    process_file_name = "full_sizing_electric_two_motors.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    problem.set_val("data:mission:sizing:main_route:reserve:duration", units="min", val=30.0)
+
+    # Baseline
+    problem.set_val("data:TLAR:range", units="NM", val=100.0)
+    # problem.set_val("data:TLAR:range", units="NM", val=175.0)
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.output_file_path = RESULTS_FOLDER_PATH / "full_sizing_elec_out_two_motors_improved.xml"
+    problem.write_outputs()
+
+    # Range tested
+    # 50, 75, 100, 125, 150, 175
+
+    # Corresponding MTOW [kg]
+    # 2092.0, 2380, 2763, 3210, 3882, 5368
+
+    # Corresponding battery mass [kg]
+    # 2.0 * 382, 2.0 * 479, 2.0 * 605, 2.0 * 757, 2.0 * 981, 2.0 * 1454
+
+
+def test_sizing_sr22_electric_two_motors_improved_plus_range_sensitivity():
+    """
+    Same tests as above except we replace the cell with a high energy density cell. In that case we
+    will take a cell from the company Amprius with a gravimetric energy density of 395 Wh/kg,
+    whereas before it was 261.4 Wh/kg
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_electric_two_motors.xml"
+    process_file_name = "full_sizing_electric_two_motors.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+
+    problem.model_options["*"] = {
+        "cell_capacity_ref": 1.34,
+        "cell_weight_ref": 11.7e-3,
+        "reference_curve_current": [100.0, 1000.0, 3000.0, 5100.0],
+        "reference_curve_relative_capacity": [1.0, 0.99, 0.98, 0.97],
+    }
+
+    problem.setup()
+
+    problem.set_val("data:mission:sizing:main_route:reserve:duration", units="min", val=30.0)
+
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:cell:c_rate_caliber",
+        val=4.0,
+        units="h**-1",
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_2:cell:c_rate_caliber",
+        val=4.0,
+        units="h**-1",
+    )
+
+    # Baseline
+    problem.set_val("data:TLAR:range", units="NM", val=100.0)
+    # problem.set_val("data:TLAR:range", units="NM", val=360.0)
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.output_file_path = (
+        RESULTS_FOLDER_PATH / "full_sizing_elec_out_two_motors_plus_improved.xml"
+    )
+    problem.write_outputs()
+
+    # Range tested
+    # 50, 75, 100, 125, 150, 175, 200, 225, 251, 275, 280, 290, 305, 315, 323, 333, 343, 353, 360
+
+    # Corresponding MTOW [kg] 1591, 1726, 1867, 2008, 2160, 2327, 2509, 2721, 2982, 3243, 3304,
+    # 3435, 3654, 3819, 3965, 4172, 4419, 4733, 4989
+
+    # Corresponding battery mass [kg] 2.0 * 209, 2.0 * 257, 2.0 * 306, 2.0 * 355, 2.0*408,
+    # 2.0 * 465, 2.0 * 527, 2.0 * 597, 681, 2.0*770, 2.0 * 790, 2.0 * 834, 2.0 * 907, 2.0 * 961,
+    # 2.0 * 1009, 2.0 * 1077, 2.0 * 1156, 2.0 * 1256, 2.0 * 1337

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -17,6 +17,7 @@ from utils.filter_residuals import filter_residuals
 DATA_FOLDER_PATH = pathlib.Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results"
 DOE_RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results_doe"
+DOE_RESULTS_FOLDER_PATH_SPLIT = pathlib.Path(__file__).parent / "results_doe_power_split"
 WORKDIR_FOLDER_PATH = pathlib.Path(__file__).parent / "workdir"
 
 
@@ -486,6 +487,60 @@ def test_sizing_sr22_hybrid():
 
     problem.output_file_path = RESULTS_FOLDER_PATH / "full_sizing_hybrid_out_mda.xml"
     problem.write_outputs()
+
+
+def test_doe_sr22_hybrid_power_split():
+    """
+    Tests a hybrid sr22 with the same climb, cruise, descent and reserve profile as the original
+    one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights) for various power
+    split.
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    power_splits = np.linspace(80, 95, 16)
+
+    for power_split in power_splits:
+        configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+        problem = configurator.get_problem()
+
+        # Create inputs
+        ref_inputs = DATA_FOLDER_PATH / xml_file_name
+        # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+        # Model options are set up straight into the configuration file
+        problem.write_needed_inputs(ref_inputs)
+        problem.read_inputs()
+        problem.setup()
+
+        # The electric motor model is very sensitive to the rated rpm of the chassis unfortunately,
+        # especially in this tests where rated power for the motor can vary between 10 and 80 kW
+        # resulting in, when looking at the reference motor family, rated rpm ranging from 6500 to
+        # 4000. So to increase confidence in the results and based on a first try, we'll set the
+        # rated rpm as a function of the hybridization ratio
+        expected_power = -3.6064 * power_split + 354.82
+        expected_rpm = np.clip(0.0864 * expected_power ** 2 - 43.22 * expected_power + 7686.8, 3250, 6500)
+
+        problem.set_val(
+            "data:propulsion:he_power_train:PMSM:motor_1:rpm_rating", val=expected_rpm, units="min**-1"
+        )
+
+        problem.set_val(
+            "data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split",
+            power_split,
+            units="percent",
+        )
+        problem.run_model()
+
+        problem.output_file_path = DOE_RESULTS_FOLDER_PATH_SPLIT / (
+            str(int(power_split)) + "_percent_split_mda.xml"
+        )
+        problem.write_outputs()
 
 
 def test_optimization_sr22_hybrid():

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -589,8 +589,11 @@ def test_optimization_sr22_hybrid_power_share():
     problem.model.add_design_var(
         name="data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_share",
         units="kW",
-        lower=150.0,
+        lower=160.0,
         upper=195.0,
+    )
+    problem.model.add_objective(
+        name="data:environmental_impact:sizing:emissions", units="kg"
     )
 
     problem.setup()

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -406,6 +406,42 @@ def test_payload_range_comparison():
     fig.show()
 
 
+def test_sizing_sr22_hybrid():
+    """
+    Tests a hybrid sr22 with the same climb, cruise, descent and reserve profile as the original
+    one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights). The only change is
+    the ratio between stall speed and reserve speed which is set at 1.3 (ratio between approach
+    and stall)
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.setup()
+
+    # om.n2(problem, show_browser=False, outfile=n2_path)
+
+    problem.run_model()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+
+    problem.write_outputs()
+
+
 def rename_variables_for_payload_range(source_file_path: pathlib.Path):
     """
     Small helper function because payload range needs data based on the operational mission while

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2025 ISAE-SUPAERO
 
 import pathlib
 from shutil import rmtree
@@ -140,7 +140,7 @@ def test_sizing_sr22_electric_original():
 def test_sizing_sr22_electric_two_motors():
     """
     Same tests as above except, to increase confidence in e-motor results we will take two "stacked"
-    motors instead of a big one, as is doable with EMRAX engine. They will be coupled by a gearbox
+    motors instead of a big one, as is doable with EMRAX motor. They will be coupled by a gearbox
     of 0 kg and 0.99 efficiency. Also, because the E-motor doesn't lose power with altitude, the
     climb rate at cruise level will be improved which should result in better energy efficiency.
     """

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -176,8 +176,8 @@ def test_sizing_sr22_electric_two_motors_improved_range_sensitivity():
     problem.set_val("data:mission:sizing:main_route:reserve:duration", units="min", val=30.0)
 
     # Baseline
-    # problem.set_val("data:TLAR:range", units="NM", val=100.0)
-    problem.set_val("data:TLAR:range", units="NM", val=50.0)
+    problem.set_val("data:TLAR:range", units="NM", val=100.0)
+    # problem.set_val("data:TLAR:range", units="NM", val=50.0)
     # problem.model.nonlinear_solver.options["rtol"] = 1e-8
 
     # om.n2(problem, show_browser=False, outfile=n2_path)
@@ -247,8 +247,8 @@ def test_sizing_sr22_electric_two_motors_improved_plus_range_sensitivity():
     )
 
     # Baseline
-    # problem.set_val("data:TLAR:range", units="NM", val=100.0)
-    problem.set_val("data:TLAR:range", units="NM", val=375.0)
+    problem.set_val("data:TLAR:range", units="NM", val=100.0)
+    # problem.set_val("data:TLAR:range", units="NM", val=375.0)
 
     # om.n2(problem, show_browser=False, outfile=n2_path)
 
@@ -271,6 +271,43 @@ def test_sizing_sr22_electric_two_motors_improved_plus_range_sensitivity():
     # Corresponding battery mass [kg]
     # 2.0 * 127, 2.0 * 171, 2.0 * 218, 2.0 * 266, 2.0 * 320, 2.0 * 379, 2.0 * 445, 2.0 * 521,
     # 2.0 * 604, 2.0 * 699, 2.0 * 812, 2.0 * 951, 2.0 * 1141, 2.0 * 1421
+
+
+def test_op_mission_with_target_improved_plus():
+    # Now we do the same for the "plus" version, a priori we could reuse the same "problem" just
+    # change the inputs
+    # ref_electric_process_file_name = "op_mission_electric.yml"
+    ref_electric_process_file_name = "payload_range_electric.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / ref_electric_process_file_name)
+    problem_electric_high_bed = configurator.get_problem()
+
+    ref_inputs_high_bed_electric = (
+        RESULTS_FOLDER_PATH / "full_sizing_elec_out_two_motors_plus_improved.xml"
+    )
+    rename_variables_for_payload_range(ref_inputs_high_bed_electric)
+
+    # Add a threshold SoC
+    datafile = oad.DataFile(ref_inputs_high_bed_electric)
+    datafile.append(
+        oad.Variable(name="data:mission:operational:threshold_SoC", val=0.0, units="percent")
+    )
+    datafile.save()
+
+    problem_electric_high_bed.write_needed_inputs(ref_inputs_high_bed_electric)
+    problem_electric_high_bed.read_inputs()
+
+    problem_electric_high_bed.model_options["*"] = {
+        "cell_capacity_ref": 1.34,
+        "cell_weight_ref": 11.7e-3,
+        "reference_curve_current": [100.0, 1000.0, 3000.0, 5100.0],
+        "reference_curve_relative_capacity": [1.0, 0.99, 0.98, 0.97],
+    }
+
+    problem_electric_high_bed.setup()
+
+    problem_electric_high_bed.run_model()
+    problem_electric_high_bed.write_outputs()
 
 
 def test_payload_range_comparison():

--- a/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
+++ b/integration_tests/cirrus_sr22/test_sizing_cirrus_sr22.py
@@ -468,8 +468,41 @@ def test_sizing_sr22_hybrid():
     _, _, residuals = problem.model.get_nonlinear_vectors()
     residuals = filter_residuals(residuals)
 
+    problem.output_file_path = RESULTS_FOLDER_PATH / "full_sizing_hybrid_out_mda.xml"
     problem.write_outputs()
 
+
+def test_optimization_sr22_hybrid():
+    """
+    Optimizes the hybrid sr22 with the same climb, cruise, descent and reserve profile as the o
+    riginal one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights).
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    tmp_problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    tmp_problem.write_needed_inputs(ref_inputs)
+
+    problem = oad.optimize_problem(DATA_FOLDER_PATH / process_file_name, overwrite=True)
+
+    # problem.setup()
+    #
+    # # om.n2(problem, show_browser=False, outfile=n2_path)
+    #
+    # problem.run_driver()
+    #
+    # problem.write_outputs()
 
 def rename_variables_for_payload_range(source_file_path: pathlib.Path):
     """

--- a/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
+++ b/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
@@ -1,0 +1,285 @@
+# This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
+# Electric Aircraft.
+# Copyright (C) 2022 ISAE-SUPAERO
+
+import pathlib
+from shutil import rmtree
+import logging
+
+import pytest
+
+import numpy as np
+import openmdao.api as om
+import fastoad.api as oad
+
+from fastga_he.gui.payload_range import payload_range_outer
+from utils.filter_residuals import filter_residuals
+
+DATA_FOLDER_PATH = pathlib.Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results_better_cells"
+ORIG_RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results"
+DOE_RESULTS_FOLDER_PATH = pathlib.Path(__file__).parent / "results_doe_better_cells"
+DOE_RESULTS_FOLDER_PATH_SPLIT = (
+    pathlib.Path(__file__).parent / "results_doe_power_split_better_cells"
+)
+WORKDIR_FOLDER_PATH = pathlib.Path(__file__).parent / "workdir"
+
+
+@pytest.fixture(scope="module")
+def cleanup():
+    """Empties results folder to avoid any conflicts."""
+    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    rmtree(WORKDIR_FOLDER_PATH, ignore_errors=True)
+
+
+def test_doe_sr22_hybrid_power_split():
+    """
+    Tests a hybrid sr22 with the same climb, cruise, descent and reserve profile as the original
+    one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights) for various power
+    split. The initial testing on this configuration revealed that the battery cells were sized in
+    energy so we will use a high energy density cell in the Ampirius catalog.
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    # power_splits = np.arange(60, 79.5, 1)
+    power_splits = [67]
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    # Model options are set up straight into the configuration file
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+
+    # In addition to a change in battery production process, the characteristics of the battery
+    # packs are changed. We will assume same polarization curve and small relative capacity effect.
+    # We need at least 4 "fake" points for the relative capacity effect as it assumed to be a
+    # deg 3 polynomial.
+    problem.model_options["*"] = {
+        "cell_capacity_ref": 4.000,
+        "cell_weight_ref": 48.0e-3,
+        "reference_curve_current": [100.0, 4000.0, 8000.0, 12000.0],
+        "reference_curve_relative_capacity": [1.0, 0.99, 0.98, 0.97],
+    }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": False}
+
+    problem.setup()
+
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:cell:c_rate_caliber",
+        val=3.0,
+        units="h**-1",
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:voltage_caliber",
+        val=830.0,
+        units="V",
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:rpm_rating",
+        val=4060.0,
+        units="min**-1",
+    )
+
+    for power_split in power_splits:
+        problem.set_val(
+            "data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split",
+            power_split,
+            units="percent",
+        )
+        problem.run_model()
+
+        problem.output_file_path = DOE_RESULTS_FOLDER_PATH_SPLIT / (
+            str(int(power_split)) + "_percent_split_mda.xml"
+        )
+        problem.write_outputs()
+
+
+def test_optimization_sr22_hybrid():
+    """
+    Optimizes the hybrid sr22 with the same climb, cruise, descent and reserve profile as the o
+    riginal one but a range of 200 nm (this represents 75% of all Cirrus SR22 flights).
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
+    problem.model.approx_totals()
+
+    problem.model.add_design_var(
+        name="data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split",
+        units="percent",
+        lower=69.0,
+        upper=85.0,
+    )
+    # We can't go lower than 69.0% otherwise we start requiring electric motor for which the rated
+    # power is above what our model can handle.
+    problem.model.add_objective(name="data:environmental_impact:sizing:emissions", units="kg")
+
+    recorder = om.SqliteRecorder("driver_cases_better_cells.sql")
+    problem.driver.add_recorder(recorder)
+
+    problem.driver.recording_options["record_desvars"] = True
+    problem.driver.recording_options["record_objectives"] = True
+
+    # In addition to a change in battery production process, the characteristics of the battery
+    # packs are changed. We will assume same polarization curve and small relative capacity effect.
+    # We need at least 4 "fake" points for the relative capacity effect as it assumed to be a
+    # deg 3 polynomial.
+    problem.model_options["*"] = {
+        "cell_capacity_ref": 4.000,
+        "cell_weight_ref": 48.0e-3,
+        "reference_curve_current": [100.0, 4000.0, 8000.0, 12000.0],
+        "reference_curve_relative_capacity": [1.0, 0.99, 0.98, 0.97],
+    }
+
+    problem.setup()
+
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:cell:c_rate_caliber",
+        val=3.0,
+        units="h**-1",
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:voltage_caliber",
+        val=830.0,
+        units="V",
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split",
+        val=80.0,
+        units="percent",
+    )
+
+    problem.run_driver()
+    problem.output_file_path = RESULTS_FOLDER_PATH / "optim_power_split.xml"
+    problem.write_outputs()
+
+
+def test_sizing_sr22_hybrid_no_lto_improved():
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("fastoad.module_management._bundle_loader").disabled = True
+    logging.getLogger("fastoad.openmdao.variables.variable").disabled = True
+
+    # Define used files depending on options
+    xml_file_name = "input_sr22_hybrid.xml"
+    process_file_name = "full_sizing_hybrid.yml"
+
+    configurator = oad.FASTOADProblemConfigurator(DATA_FOLDER_PATH / process_file_name)
+    problem = configurator.get_problem()
+    problem.input_file_path = RESULTS_FOLDER_PATH / "full_sizing_hybrid_in_no_LTO_improved.xml"
+
+    # Create inputs
+    ref_inputs = DATA_FOLDER_PATH / xml_file_name
+    # api.list_modules(pth.join(DATA_FOLDER_PATH, process_file_name), force_text_output=True)
+
+    problem.write_needed_inputs(ref_inputs)
+
+    # Starting from the repartition in the previous test, we add a smoothing zone
+    smoothing_zone_width = 10
+    smoothing_zone_width_descent = min(smoothing_zone_width, 12)  # To avoid going into cruise
+    smoothing_zone_width_climb = min(smoothing_zone_width, 22)  # To avoid going into cruise
+    power_split = (
+        100.0
+        * np.concatenate(
+            (
+                np.zeros(12),  # Taxi out and climb
+                np.linspace(0, 1, smoothing_zone_width_climb + 2)[1:-1],  # Transition
+                np.ones(
+                    61 - smoothing_zone_width_descent - smoothing_zone_width_climb
+                ),  # End of climb, cruise and start of descent
+                np.linspace(1, 0, smoothing_zone_width_descent + 2)[1:-1],  # Transition
+                np.zeros(8),  # End of descent
+                np.ones(10),  # Reserve
+                np.zeros(1),  # Taxi in
+            )
+        )
+    )
+    datafile = oad.DataFile(problem.input_file_path)
+    datafile[
+        "data:propulsion:he_power_train:planetary_gear:planetary_gear_1:power_split"
+    ].value = power_split
+    datafile.save()
+
+    problem.read_inputs()
+
+    # We use here the 10 Ah Ultra-High Power Cell from Ampirius but using its original
+    # characteristics we get a convergence error because one cell weighs too much. So instead, we
+    # will use more smaller cells
+    problem.model_options["*"] = {
+        "cell_capacity_ref": 1.0000,
+        "cell_weight_ref": 9.20e-3,
+        "reference_curve_current": [10.0, 3300.0, 6600.0, 10000.0],
+        "reference_curve_relative_capacity": [1.0, 0.99, 0.98, 0.97],
+    }
+    problem.model_options["*motor_1*"] = {"adjust_rpm_rating": False}
+
+    problem.setup()
+
+    problem.model.nonlinear_solver.options["use_aitken"] = True
+    problem.model.nonlinear_solver.options["aitken_max_factor"] = 0.8
+    problem.model.nonlinear_solver.options["aitken_min_factor"] = 0.33
+    problem.model.nonlinear_solver.options["aitken_initial_factor"] = 0.8
+    problem.model.nonlinear_solver.options["maxiter"] = 30
+    problem.model.nonlinear_solver.options["stall_limit"] = 5
+    problem.model.nonlinear_solver.options["stall_tol"] = 3e-6
+
+    # We will need the biggest motor we can get, the EMRAX348
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:torque_max", val=1000.0, units="N*m"
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:rpm_rating", val=3250.0, units="min**-1"
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:voltage_caliber", val=830.0, units="V"
+    )
+    problem.set_val(
+        "data:propulsion:he_power_train:battery_pack:battery_pack_1:cell:c_rate_caliber",
+        val=10.0,
+        units="h**-1",
+    )
+
+    problem.run_model()
+
+    problem.output_file_path = RESULTS_FOLDER_PATH / "full_sizing_hybrid_out_no_LTO_improved.xml"
+    problem.write_outputs()
+
+    _, _, residuals = problem.model.get_nonlinear_vectors()
+    residuals = filter_residuals(residuals)
+    # Also rename the .csv so they are not overwritten (because the conf file and pt watcher files
+    # are shared).
+    if pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion_no_LTO_improved.csv").exists():
+        pathlib.Path(RESULTS_FOLDER_PATH / "hybrid_propulsion_no_LTO_improved.csv").unlink()
+    mission_file = pathlib.Path(ORIG_RESULTS_FOLDER_PATH / "hybrid_propulsion.csv")
+    mission_file.rename(RESULTS_FOLDER_PATH / "hybrid_propulsion_no_LTO_improved.csv")
+
+    if pathlib.Path(
+        RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv"
+    ).exists():
+        pathlib.Path(
+            RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv"
+        ).unlink()
+    pt_watcher_file = pathlib.Path(ORIG_RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher.csv")
+    pt_watcher_file.rename(RESULTS_FOLDER_PATH / "hybrid_propulsion_pt_watcher_no_LTO_improved.csv")

--- a/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
+++ b/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2025 ISAE-SUPAERO
 
 import pathlib
 from shutil import rmtree

--- a/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
+++ b/integration_tests/cirrus_sr22/test_sizing_hybrid_cirrus_better_cells.py
@@ -12,7 +12,6 @@ import numpy as np
 import openmdao.api as om
 import fastoad.api as oad
 
-from fastga_he.gui.payload_range import payload_range_outer
 from utils.filter_residuals import filter_residuals
 
 DATA_FOLDER_PATH = pathlib.Path(__file__).parent / "data"

--- a/src/fastga_he/gui/lca_impact.py
+++ b/src/fastga_he/gui/lca_impact.py
@@ -872,7 +872,7 @@ def _update_fig_axis(fig: go.Figure):
     # You may wonder why I set the y-axis to the right, well that's because if it's on the left
     # changing the tick font changes the range !
     # You could try to solve that problem, but if you don't manage to update the counter below:
-    # hours_wasted: 1.5
+    # hours_wasted: 1.75
 
 
 def _get_list_contributing_components_and_variables(

--- a/src/fastga_he/models/environmental_impacts/lca.py
+++ b/src/fastga_he/models/environmental_impacts/lca.py
@@ -15,11 +15,10 @@ from fastoad.module_management.constants import ModelDomain
 try:
     # Ruff, please ignore this unused import it's just to check that the opt dependencies are here
     from lca_modeller.io.configuration import LCAProblemConfigurator  # noqa: F401
+
+    LCA_AVAILABLE = True
 except ImportError:
-    raise ImportError(
-        "The modules with the fastga_he.lca.legacy id can only be used with lca optional "
-        "dependency group.\n Install it with poetry install --extras lca"
-    )
+    LCA_AVAILABLE = False
 
 
 import fastga_he.models.propulsion.components as he_comp
@@ -64,6 +63,12 @@ class LCA(om.Group):
         self.configurator = FASTGAHEPowerTrainConfigurator()
 
     def initialize(self):
+        if not LCA_AVAILABLE:
+            raise ImportError(
+                "The modules with the fastga_he.lca.legacy id can only be used with lca optional "
+                "dependency group.\n Install it with poetry install --extras lca"
+            )
+
         self.options.declare(
             name="power_train_file_path",
             default=None,

--- a/src/fastga_he/models/environmental_impacts/lca_core.py
+++ b/src/fastga_he/models/environmental_impacts/lca_core.py
@@ -6,7 +6,6 @@ import pathlib
 import re
 import shutil
 import logging
-from typing import Dict, List
 
 # To properly handle the case where the optional dependencies are not installed
 try:

--- a/src/fastga_he/models/environmental_impacts/lca_core.py
+++ b/src/fastga_he/models/environmental_impacts/lca_core.py
@@ -14,11 +14,10 @@ try:
     import dotenv
     import lca_algebraic as agb
     from lca_modeller.io.configuration import LCAProblemConfigurator
+
+    LCA_AVAILABLE = True
 except ImportError:
-    raise ImportError(
-        "This feature is only usable with the lca optional dependency group.\n"
-        "Install it with poetry install --extras lca"
-    )
+    LCA_AVAILABLE = False
 
 import numpy as np
 import openmdao.api as om
@@ -75,6 +74,12 @@ class LCACore(om.ExplicitComponent):
         self.clean_method_name = set()
 
     def initialize(self):
+        if not LCA_AVAILABLE:
+            raise ImportError(
+                "This feature is only usable with the lca optional dependency group.\n"
+                "Install it with poetry install --extras lca"
+            )
+
         self.options.declare(
             name="power_train_file_path",
             default=None,
@@ -439,15 +444,19 @@ class LCACore(om.ExplicitComponent):
 
     def compute_impacts_from_lambdas(
         self,
-        lambdas: List[agb.LambdaWithParamNames],
+        lambdas,
         axis: str,
-        **params: Dict[str, agb.SingleOrMultipleFloat],
+        **params,
     ):
         """
         Modified version of compute_impacts from lca_algebraic.
         More like a wrapper of _postLCAAlgebraic, to avoid calling _preLCAAlgebraic which is
         unnecessarily time-consuming when lambdas have already been calculated and doesn't have to
         be updated.
+
+        :param lambdas: List[agb.LambdaWithParamNames]
+        :param axis: str
+        :param **params: Dict[str, agb.SingleOrMultipleFloat]
         """
         dfs = dict()
 

--- a/src/fastga_he/models/performances/mission_vector/to_csv.py
+++ b/src/fastga_he/models/performances/mission_vector/to_csv.py
@@ -29,6 +29,7 @@ CSV_DATA_LABELS = [
     "cl_htp",
     "cl_aircraft",
     "cd_aircraft",
+    "l_d_aircraft",
     "delta_Cl",
     "delta_Cd",
     "delta_Cm",
@@ -204,7 +205,7 @@ class ToCSV(om.ExplicitComponent):
         coeff_k_htp = inputs["data:aerodynamics:horizontal_tail:cruise:induced_drag_coefficient"]
         delta_cl = inputs["delta_Cl"]
         delta_cd = inputs["delta_Cd"]
-        delta_cm = inputs["delta_Cd"]
+        delta_cm = inputs["delta_Cm"]
         delta_m = inputs["delta_m"] * np.pi / 180.0
         cl_delta_m = inputs["data:aerodynamics:elevator:low_speed:CL_delta"]
         cd_delta_m = inputs["data:aerodynamics:elevator:low_speed:CD_delta"]
@@ -219,6 +220,8 @@ class ToCSV(om.ExplicitComponent):
             + coeff_k_htp * cl_htp**2.0
             + (cd_delta_m * delta_m**2.0)
         )
+
+        l_d_aircraft = cl_aircraft / cd_tot
 
         thrust = inputs["thrust"]
         thrust_rate = inputs["thrust_rate_t"]
@@ -259,6 +262,7 @@ class ToCSV(om.ExplicitComponent):
             results_df["cl_htp"] = cl_htp
             results_df["cl_aircraft"] = cl_aircraft
             results_df["cd_aircraft"] = cd_tot
+            results_df["l_d_aircraft"] = l_d_aircraft
             results_df["delta_Cl"] = delta_cl
             results_df["delta_Cd"] = delta_cd
             results_df["delta_Cm"] = delta_cm

--- a/src/fastga_he/models/performances/op_mission_vector/op_mission_vector.py
+++ b/src/fastga_he/models/performances/op_mission_vector/op_mission_vector.py
@@ -262,11 +262,14 @@ class OperationalMissionVector(om.Group):
                 "data:mission:sizing:main_route:reserve:duration",
                 "data:mission:operational:reserve:duration",
             ),
-            (
-                "settings:mission:sizing:main_route:reserve:speed:k_factor",
-                "settings:operational:reserve:speed:k_factor",
-            ),
         ]
+        if self.is_service_active(SUBMODEL_RESERVE_SPEED_VECT):
+            initialization_input_promote_list.append(
+                (
+                    "settings:mission:sizing:main_route:reserve:speed:k_factor",
+                    "settings:operational:reserve:speed:k_factor",
+                )
+            )
         initialization_output_promote_list = []
 
         # Three case can happen when detecting which submodel is active:
@@ -1211,6 +1214,22 @@ class OperationalMissionVector(om.Group):
         # One point to be careful about is that the non_linear guessing is done before any model is
         # actually ran. Therefore it relies on initial values for other variables and problem
         # inputs. This should be kept in mind !
+
+        if self.is_service_active(SUBMODEL_CLIMB_SPEED_VECT):
+            cl_max_clean = inputs[
+                "initialization.initialize_climb_speed.data:aerodynamics:wing:low_speed:CL_max_clean"
+            ].item()
+        elif self.is_service_active(SUBMODEL_DESCENT_SPEED_VECT):
+            cl_max_clean = inputs[
+                "initialization.initialize_descent_speed.data:aerodynamics:wing:low_speed:CL_max_clean"
+            ].item()
+        elif self.is_service_active(SUBMODEL_RESERVE_SPEED_VECT):
+            cl_max_clean = inputs[
+                "initialization.initialize_reserve_speed.data:aerodynamics:wing:low_speed:CL_max_clean"
+            ].item()
+        else:
+            cl_max_clean = 1.5
+
         dummy_tas_array = self._get_initial_guess_true_airspeed(
             mass=outputs["solve_equilibrium.update_mass.mass"],
             wing_area=inputs[
@@ -1219,9 +1238,7 @@ class OperationalMissionVector(om.Group):
             cruise_altitude=inputs[
                 "initialization.initialize_altitude.data:mission:sizing:main_route:cruise:altitude"
             ].item(),
-            cl_max_clean=inputs[
-                "initialization.initialize_reserve_speed.data:aerodynamics:wing:low_speed:CL_max_clean"
-            ].item(),
+            cl_max_clean=cl_max_clean,
             cruise_tas=inputs["initialization.initialize_airspeed.data:TLAR:v_cruise"].item(),
             reserve_altitude=inputs[
                 "initialization.initialize_altitude.data:mission:sizing:main_route:reserve:altitude"

--- a/src/fastga_he/models/performances/payload_range/payload_range.py
+++ b/src/fastga_he/models/performances/payload_range/payload_range.py
@@ -188,6 +188,8 @@ class ComputePayloadRange(om.ExplicitComponent):
                 promotes=["*"],
             )
 
+        # TODO: find a way to do this that doesn't involve accessing private attribute
+        self.cached_problem.model_options = self._problem_meta["model_options"]
         self.cached_problem.setup()
 
         # There are four points in the payload range as computed by this framework. Points A, B,

--- a/src/fastga_he/models/propulsion/components/loads/pmsm/components/cstr_ensure.py
+++ b/src/fastga_he/models/propulsion/components/loads/pmsm/components/cstr_ensure.py
@@ -13,6 +13,8 @@ import numpy as np
 
 import fastoad.api as oad
 
+SERVICE_CONSTRAINTS_PMSM_RPM_ENSURE = "fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure"
+
 oad.RegisterSubmodel.active_models[SUBMODEL_CONSTRAINTS_PMSM_VOLTAGE] = (
     "fastga_he.submodel.propulsion.constraints.pmsm.voltage.ensure"
 )
@@ -75,9 +77,7 @@ class ConstraintsTorqueEnsure(om.ExplicitComponent):
         )
 
 
-@oad.RegisterSubmodel(
-    SUBMODEL_CONSTRAINTS_PMSM_RPM, "fastga_he.submodel.propulsion.constraints.pmsm.rpm.ensure"
-)
+@oad.RegisterSubmodel(SUBMODEL_CONSTRAINTS_PMSM_RPM, SERVICE_CONSTRAINTS_PMSM_RPM_ENSURE)
 class ConstraintsRPMEnsure(om.ExplicitComponent):
     """
     Class that computes the difference between the maximum rpm seen by the pmsm during the

--- a/src/fastga_he/models/propulsion/components/loads/pmsm/components/cstr_pmsm_adjust_rpm_rating.py
+++ b/src/fastga_he/models/propulsion/components/loads/pmsm/components/cstr_pmsm_adjust_rpm_rating.py
@@ -1,0 +1,68 @@
+#  This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
+#  Electric Aircraft.
+#  Copyright (C) 2025 ISAE-SUPAERO
+
+import numpy as np
+import openmdao.api as om
+
+
+class ConstraintsPMSMAdjustRPMRating(om.ExplicitComponent):
+    """
+    The low robustness of the electric motor model and the strong dependency of the coherence of the
+    module on the correlation between rating shaft power and rpm rating has already been
+    established. This module proposes to auto adjust the rpm rating to improve stability and
+    coherence of results when doing some design space exploration. It will of course not be enabled
+    by default.
+    """
+
+    def initialize(self):
+        self.options.declare(
+            name="motor_id", default=None, desc="Identifier of the motor", allow_none=False
+        )
+
+    def setup(self):
+        motor_id = self.options["motor_id"]
+
+        self.add_input(
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":shaft_power_rating",
+            units="kW",
+            val=np.nan,
+            desc="Value of the maximum power the PMSM can provide, used for sizing",
+        )
+
+        self.add_output(
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":rpm_rating",
+            units="min**-1",
+            val=6000.0,
+            desc="Max continuous rpm of the motor",
+        )
+
+    def setup_partials(self):
+        self.declare_partials(of="*", wrt="*", method="exact")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        motor_id = self.options["motor_id"]
+
+        shaft_power_rating = inputs[
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":shaft_power_rating"
+        ]
+        outputs["data:propulsion:he_power_train:PMSM:" + motor_id + ":rpm_rating"] = np.clip(
+            0.0864 * shaft_power_rating**2 - 43.22 * shaft_power_rating + 7686.8, 3250.0, 8000.0
+        )
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+        motor_id = self.options["motor_id"]
+
+        shaft_power_rating = inputs[
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":shaft_power_rating"
+        ]
+        expected_rpm = 0.0864 * shaft_power_rating**2 - 43.22 * shaft_power_rating + 7686.8
+
+        partials[
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":rpm_rating",
+            "data:propulsion:he_power_train:PMSM:" + motor_id + ":shaft_power_rating",
+        ] = np.where(
+            expected_rpm == np.clip(expected_rpm, 3250.0, 8000.0),
+            2.0 * 0.0864 * shaft_power_rating - 43.22,
+            1e-6,
+        )

--- a/src/fastga_he/models/propulsion/components/loads/pmsm/unit_tests/test_pmsm.py
+++ b/src/fastga_he/models/propulsion/components/loads/pmsm/unit_tests/test_pmsm.py
@@ -46,6 +46,7 @@ from ..components.cstr_ensure import (
     ConstraintsVoltageEnsure,
 )
 from ..components.cstr_pmsm import ConstraintPMSMPowerRateMission
+from ..components.cstr_pmsm_adjust_rpm_rating import ConstraintsPMSMAdjustRPMRating
 
 from ..components.sizing_pmsm import SizingPMSM
 from ..components.perf_pmsm import PerformancesPMSM
@@ -387,6 +388,22 @@ def test_constraint_power_for_power_rate():
     assert problem.get_val(
         "data:propulsion:he_power_train:PMSM:motor_1:shaft_power_rating", units="kW"
     ) == pytest.approx(70.0, rel=1e-2)
+
+    problem.check_partials(compact_print=True)
+
+
+def test_adjust_rpm():
+    ivc = om.IndepVarComp()
+    ivc.add_output(
+        "data:propulsion:he_power_train:PMSM:motor_1:shaft_power_rating", val=70.0, units="kW"
+    )
+
+    # Run problem and check obtained value(s) is/(are) correct
+    problem = run_system(ConstraintsPMSMAdjustRPMRating(motor_id="motor_1"), ivc)
+
+    assert problem.get_val(
+        "data:propulsion:he_power_train:PMSM:motor_1:rpm_rating", units="min**-1"
+    ) == pytest.approx(5084.0, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_emissions.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_emissions.py
@@ -12,6 +12,7 @@ from .perf_inflight_h2o_emissions import PerformancesICEInFlightH2OEmissions
 from .perf_inflight_hc_emissions import PerformancesICEInFlightHCEmissions
 from .perf_inflight_lead_emissions import PerformancesICEInFlightLeadEmissions
 from .perf_inflight_emissions_sum import PerformancesICEInFlightEmissionsSum
+from .perf_inflight_lto_emissions_sum import PerformancesICELTOEmissionsSum
 
 
 class PerformancesICEInFlightEmissions(om.Group):
@@ -86,6 +87,13 @@ class PerformancesICEInFlightEmissions(om.Group):
         self.add_subsystem(
             name="emissions_sum",
             subsys=PerformancesICEInFlightEmissionsSum(
+                ice_id=ice_id, number_of_points=number_of_points
+            ),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            name="emissions_lto_sum",
+            subsys=PerformancesICELTOEmissionsSum(
                 ice_id=ice_id, number_of_points=number_of_points
             ),
             promotes=["*"],

--- a/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_emissions.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_emissions.py
@@ -93,8 +93,6 @@ class PerformancesICEInFlightEmissions(om.Group):
         )
         self.add_subsystem(
             name="emissions_lto_sum",
-            subsys=PerformancesICELTOEmissionsSum(
-                ice_id=ice_id, number_of_points=number_of_points
-            ),
+            subsys=PerformancesICELTOEmissionsSum(ice_id=ice_id, number_of_points=number_of_points),
             promotes=["*"],
         )

--- a/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_lto_emissions_sum.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_lto_emissions_sum.py
@@ -1,0 +1,89 @@
+# This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
+# Electric Aircraft.
+# Copyright (C) 2022 ISAE-SUPAERO
+
+import openmdao.api as om
+import numpy as np
+
+from .perf_inflight_emissions_sum import SPECIES_LIST
+
+THRESHOLD_ALTITUDE_LTO = 3000.0  # In ft
+
+
+class PerformancesICELTOEmissionsSum(om.ExplicitComponent):
+    """
+    Addition of the emissions of all pollutants for steps of the flight in the LTO cycle. The
+    threshold altitude's value is 3000ft as taken from :cite:`brooker:2006`.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.lto_mask = None
+
+    def initialize(self):
+        self.options.declare(
+            "number_of_points", default=1, desc="number of equilibrium to be treated"
+        )
+        self.options.declare(
+            name="ice_id",
+            default=None,
+            desc="Identifier of the Internal Combustion Engine",
+            allow_none=False,
+        )
+
+    def setup(self):
+        number_of_points = self.options["number_of_points"]
+        ice_id = self.options["ice_id"]
+
+        self.add_input("altitude", val=np.full(number_of_points, np.nan), units="ft")
+
+        for specie in SPECIES_LIST:
+            self.add_input(specie + "_emissions", val=np.full(number_of_points, np.nan), units="g")
+            # For the LCA module we will adopt the following nomenclature:
+            # "LCA" + phase + component + pollutant
+            self.add_output(
+                "data:environmental_impact:operation:sizing:he_power_train:ICE:"
+                + ice_id
+                + ":"
+                + specie
+                + "_LTO",
+                units="g",
+                val=0.0,
+            )
+            self.declare_partials(
+                of="data:environmental_impact:operation:sizing:he_power_train:ICE:"
+                + ice_id
+                + ":"
+                + specie
+                + "_LTO",
+                wrt=specie + "_emissions",
+                rows=np.zeros(number_of_points),
+                cols=np.arange(number_of_points),
+            )
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        ice_id = self.options["ice_id"]
+        self.lto_mask = np.where(inputs["altitude"] < THRESHOLD_ALTITUDE_LTO, 1.0, 0.0)
+
+        for specie in SPECIES_LIST:
+            outputs[
+                "data:environmental_impact:operation:sizing:he_power_train:ICE:"
+                + ice_id
+                + ":"
+                + specie
+                + "_LTO"
+            ] = np.sum(inputs[specie + "_emissions"] * self.lto_mask)
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+        ice_id = self.options["ice_id"]
+
+        for specie in SPECIES_LIST:
+            partials[
+                "data:environmental_impact:operation:sizing:he_power_train:ICE:"
+                + ice_id
+                + ":"
+                + specie
+                + "_LTO",
+                specie + "_emissions",
+            ] = self.lto_mask

--- a/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_lto_emissions_sum.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/components/perf_inflight_lto_emissions_sum.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2025 ISAE-SUPAERO
 
 import openmdao.api as om
 import numpy as np

--- a/src/fastga_he/models/propulsion/components/source/ice/unit_tests/test_ice.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/unit_tests/test_ice.py
@@ -48,6 +48,7 @@ from ..components.perf_inflight_h2o_emissions import PerformancesICEInFlightH2OE
 from ..components.perf_inflight_hc_emissions import PerformancesICEInFlightHCEmissions
 from ..components.perf_inflight_lead_emissions import PerformancesICEInFlightLeadEmissions
 from ..components.perf_inflight_emissions_sum import PerformancesICEInFlightEmissionsSum
+from ..components.perf_inflight_lto_emissions_sum import PerformancesICELTOEmissionsSum
 from ..components.perf_inflight_emissions import PerformancesICEInFlightEmissions
 
 from ..components.sizing_ice import SizingICE
@@ -832,6 +833,143 @@ def test_in_flight_emissions_sum():
     assert problem.get_val(
         "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:lead", units="g"
     ) == pytest.approx(57.27916, rel=1e-2)
+
+    problem.check_partials(compact_print=True)
+
+    # Run problem and check obtained value(s) is/(are) correct
+    problem = run_system(
+        PerformancesICEInFlightEmissionsSum(
+            ice_id="ice_1", number_of_points=NB_POINTS_TEST, number_of_points_reserve=2
+        ),
+        ivc,
+    )
+
+    # For sanity, just to check that the option doesn't change the main results
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:CO2", units="kg"
+    ) == pytest.approx(223.634, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:CO2_main_route",
+        units="kg",
+    ) == pytest.approx(169.26, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:lead_main_route",
+        units="g",
+    ) == pytest.approx(43.3524, rel=1e-2)
+
+    problem.check_partials(compact_print=True)
+
+
+def test_lto_emissions_sum():
+    ivc = om.IndepVarComp()
+    ivc.add_output("altitude", val=np.linspace(8000.0, 0.0, NB_POINTS_TEST), units="ft")
+    ivc.add_output(
+        "CO2_emissions",
+        units="g",
+        val=np.array(
+            [
+                15872.0,
+                17050.0,
+                18290.0,
+                19623.0,
+                21111.0,
+                22723.0,
+                24459.0,
+                26164.0,
+                28210.0,
+                30132.0,
+            ]
+        ),
+    )
+    ivc.add_output(
+        "CO_emissions",
+        units="g",
+        val=np.array(
+            [4085.76, 4389.0, 4708.2, 5051.34, 5434.38, 5849.34, 6296.22, 6735.12, 7261.8, 7756.56]
+        ),
+    )
+    ivc.add_output(
+        "NOx_emissions",
+        units="g",
+        val=np.array(
+            [16.0768, 17.27, 18.526, 19.8762, 21.3834, 23.0162, 24.7746, 26.5016, 28.574, 30.5208]
+        ),
+    )
+    ivc.add_output(
+        "SOx_emissions",
+        units="g",
+        val=np.array([2.1504, 2.31, 2.478, 2.6586, 2.8602, 3.0786, 3.3138, 3.5448, 3.822, 4.0824]),
+    )
+    ivc.add_output(
+        "H2O_emissions",
+        units="g",
+        val=np.array(
+            [
+                6333.44,
+                6803.5,
+                7298.3,
+                7830.21,
+                8423.97,
+                9067.21,
+                9759.93,
+                10440.28,
+                11256.7,
+                12023.64,
+            ]
+        ),
+    )
+    ivc.add_output(
+        "HC_emissions",
+        units="g",
+        val=np.array(
+            [
+                96.59904,
+                103.7685,
+                111.3153,
+                119.42811,
+                128.48427,
+                138.29511,
+                148.86063,
+                159.23748,
+                171.6897,
+                183.38724,
+            ]
+        ),
+    )
+    ivc.add_output(
+        "lead_emissions",
+        units="g",
+        val=np.array(
+            [4.06528, 4.367, 4.6846, 5.02602, 5.40714, 5.82002, 6.26466, 6.70136, 7.2254, 7.71768]
+        ),
+    )
+
+    # Run problem and check obtained value(s) is/(are) correct
+    problem = run_system(
+        PerformancesICELTOEmissionsSum(ice_id="ice_1", number_of_points=NB_POINTS_TEST), ivc
+    )
+
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:CO2_LTO", units="kg"
+    ) == pytest.approx(108.965, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:CO_LTO", units="kg"
+    ) == pytest.approx(28.05, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:NOx_LTO", units="g"
+    ) == pytest.approx(110.371, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:SOx_LTO", units="g"
+    ) == pytest.approx(14.763, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:H2O_LTO", units="kg"
+    ) == pytest.approx(43.48055, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:HC_LTO", units="g"
+    ) == pytest.approx(663.175, rel=1e-2)
+    assert problem.get_val(
+        "data:environmental_impact:operation:sizing:he_power_train:ICE:ice_1:lead_LTO", units="g"
+    ) == pytest.approx(27.9091, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/source/ice/unit_tests/test_ice.py
+++ b/src/fastga_he/models/propulsion/components/source/ice/unit_tests/test_ice.py
@@ -499,6 +499,7 @@ def test_performances_ice():
         val=np.linspace(150.0, 250.0, NB_POINTS_TEST),
         units="kW",
     )
+    ivc.add_output("altitude", val=np.linspace(8000.0, 0.0, NB_POINTS_TEST), units="ft")
     ivc.add_output(
         "rpm",
         val=np.linspace(2500.0, 2699.0, NB_POINTS_TEST),
@@ -1004,6 +1005,7 @@ def test_in_flight_emissions():
         val=np.array([5.12, 5.5, 5.9, 6.33, 6.81, 7.33, 7.89, 8.44, 9.1, 9.72]),
         units="kg",
     )
+    ivc.add_output("altitude", val=np.linspace(8000.0, 0.0, NB_POINTS_TEST), units="ft")
 
     # Run problem and check obtained value(s) is/(are) correct
     problem = run_system(

--- a/src/fastga_he/powertrain_builder/resources/registered_components.py
+++ b/src/fastga_he/powertrain_builder/resources/registered_components.py
@@ -596,6 +596,7 @@ ICE = {
     MP: [
         {"torque_out": "N*m"},
         {"specific_fuel_consumption": "kg/kW/h"},
+        {"equivalent_SL_power": "kW"},
         {"mean_effective_pressure": "bar"},
         {"fuel_consumption": "kg/h"},
         {"fuel_consumed_t": "kg"},

--- a/src/fastga_he/powertrain_builder/resources/registered_components.py
+++ b/src/fastga_he/powertrain_builder/resources/registered_components.py
@@ -587,7 +587,7 @@ ICE = {
     CN_ID: "ice_id",
     CT: "ICE",
     ATT: None,
-    PT: ["time_step", "density", "settings:*"],
+    PT: ["time_step", "density", "settings:*", "altitude"],
     SPT: [],
     PTS: [],
     IN: [(None, "fuel_consumed_t")],

--- a/utils/filter_residuals.py
+++ b/utils/filter_residuals.py
@@ -12,7 +12,10 @@ def filter_residuals(residuals: DefaultTransfer):
     filtered_residuals = {}
 
     for residual in residuals._views_flat:
-        if np.isnan(residuals._views_flat[residual]).any():
+        if (
+            np.isnan(residuals._views_flat[residual]).any()
+            or np.isinf(residuals._views_flat[residual]).any()
+        ):
             filtered_residuals[residual] = residuals._views_flat[residual]
 
     return filtered_residuals


### PR DESCRIPTION
Added electric and hybrid version of the Cirrus SR22 with various hybridization schemes and various cells.

Also added some small improvements:
- The writing of LTO emissions for ICEngine
- The aircraft L/D in the output .csv file
- Reverted the handling of the missing imports in the LCA module because of an upcoming PR in FAST-OAD-core