### PR TITLE
Resolve module import failure message raised by FAST-OAD

### DIFF
--- a/src/fastga_he/models/performances/methodology/residuals_computation.py
+++ b/src/fastga_he/models/performances/methodology/residuals_computation.py
@@ -7,7 +7,7 @@ import os.path as pth
 import numpy as np
 import openmdao.api as om
 
-from modules.mtow_loop import SizingLoopMTOW
+from .modules.mtow_loop import SizingLoopMTOW
 
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
 

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/stale/sizing_h2_fuel_system_cg_x.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/stale/sizing_h2_fuel_system_cg_x.py
@@ -5,7 +5,7 @@
 import numpy as np
 import openmdao.api as om
 
-from ..constants import POSSIBLE_POSITION
+from ...constants import POSSIBLE_POSITION
 
 
 class SizingH2FuelSystemCGX(om.ExplicitComponent):

--- a/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/stale/sizing_h2_fuel_system_cg_y.py
+++ b/src/fastga_he/models/propulsion/components/connectors/h2_fuel_system/components/stale/sizing_h2_fuel_system_cg_y.py
@@ -5,7 +5,7 @@
 import numpy as np
 import openmdao.api as om
 
-from ..constants import POSSIBLE_POSITION
+from ...constants import POSSIBLE_POSITION
 
 
 class SizingH2FuelSystemCGY(om.ExplicitComponent):

--- a/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_complement_data.py
+++ b/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_complement_data.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
-from turboshaft_components.turboshaft_off_design_fuel import Turboshaft
+from .turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
+from .turboshaft_components.turboshaft_off_design_fuel import Turboshaft
 
 THERMODYNAMIC_POWER_COLUMN_NAME = "Design Power (kW)"
 OPR_COLUMN_NAME = "Design OPR (-)"

--- a/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_data_generation.py
+++ b/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_data_generation.py
@@ -13,12 +13,12 @@ import pandas as pd
 
 from pyDOE2 import lhs
 
-from turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
-from turboshaft_components.turboshaft_off_design_max_power import (
+from .turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
+from .turboshaft_components.turboshaft_off_design_max_power import (
     TurboshaftMaxPowerOPRLimit,
     TurboshaftMaxPowerITTLimit,
 )
-from turboshaft_components.turboshaft_off_design_fuel import Turboshaft
+from .turboshaft_components.turboshaft_off_design_fuel import Turboshaft
 
 
 def get_ivc_all_data(

--- a/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_data_generation_fc_v2.py
+++ b/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_data_generation_fc_v2.py
@@ -12,8 +12,8 @@ import pandas as pd
 
 from pyDOE2 import lhs
 
-from turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
-from turboshaft_components.turboshaft_off_design_fuel import Turboshaft
+from .turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
+from .turboshaft_components.turboshaft_off_design_fuel import Turboshaft
 
 
 def get_ivc_all_data(power_design, t41t_design, opr_design, altitude_design, mach_design):

--- a/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_max_power_v2.py
+++ b/src/fastga_he/models/propulsion/components/source/turboshaft/methodology/run_turboshaft_max_power_v2.py
@@ -13,8 +13,8 @@ import pandas as pd
 
 from pyDOE2 import lhs
 
-from turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
-from turboshaft_components.turboshaft_off_design_max_power import (
+from .turboshaft_components.turboshaft_geometry_computation import DesignPointCalculation
+from .turboshaft_components.turboshaft_off_design_max_power import (
     TurboshaftMaxPowerOPRLimit,
     TurboshaftMaxPowerITTLimit,
 )

--- a/src/fastga_he/models/propulsion/sub_components/heat_sink/unit_tests/test_heat_sink.py
+++ b/src/fastga_he/models/propulsion/sub_components/heat_sink/unit_tests/test_heat_sink.py
@@ -6,7 +6,6 @@ import os.path as pth
 import openmdao.api as om
 import pytest
 
-from ..components.sizing_heat_sink_dimension import SizingHeatSinkDimension
 from ..components.sizing_heat_sink_tube_length import SizingHeatSinkTubeLength
 from ..components.sizing_heat_sink_tube_mass_flow import SizingHeatSinkTubeMassFlow
 from ..components.sizing_heat_sink_coolant_prandtl import SizingHeatSinkCoolantPrandtl
@@ -27,26 +26,6 @@ from tests.testing_utilities import run_system, get_indep_var_comp, list_inputs
 
 XML_FILE = "sample_heat_sink.xml"
 PREFIX = PT_DATA_PREFIX + "inverter:inverter_1"
-
-
-def test_dimension_heat_sink():
-    # Research independent input value in .xml file
-    ivc = get_indep_var_comp(
-        list_inputs(SizingHeatSinkDimension(prefix=PREFIX)),
-        __file__,
-        XML_FILE,
-    )
-
-    problem = run_system(SizingHeatSinkDimension(prefix=PREFIX), ivc)
-
-    assert problem.get_val(PREFIX + ":heat_sink:length", units="m") == pytest.approx(
-        0.2145, rel=1e-2
-    )
-    assert problem.get_val(PREFIX + ":heat_sink:width", units="m") == pytest.approx(
-        0.1716, rel=1e-2
-    )
-
-    problem.check_partials(compact_print=True)
 
 
 def test_length_heat_sink_tube():


### PR DESCRIPTION
This PR resolves the import faliure message raised by FAST-OAD due to issue with relative path definitions. 