### PR TITLE
Introduce new entries in the `FASTGAHEPowerTrainConfigurator` cache 

### DIFF
--- a/src/fastga_he/powertrain_builder/powertrain.py
+++ b/src/fastga_he/powertrain_builder/powertrain.py
@@ -2097,6 +2097,11 @@ class FASTGAHEPowerTrainConfigurator:
             ]
 
     def _reset_cache_instance(self):
+        """
+        This function resets the cache instances of a PT file that already has registered cache
+        instances but modified during calculation. This will only be triggered during the load
+        process.
+        """
         pt_cache = FASTGAHEPowerTrainConfigurator._cache[self._power_train_file]
         last_mod_time = pathlib.Path(self._power_train_file).lstat().st_mtime
         if pt_cache and pt_cache.get("last_mod_time") != last_mod_time:
@@ -3125,6 +3130,9 @@ class FASTGAHEPowerTrainConfigurator:
         # If the powertrain configuration file is a temporary copy or dedicated for a test,
         # the connection test will be omitted
         if self._power_train_file.endswith("_temp_copy.yml"):
+            FASTGAHEPowerTrainConfigurator._cache[self._power_train_file]["last_mod_time"] = (
+                pathlib.Path(self._power_train_file).lstat().st_mtime
+            )
             return True
 
         # If cache is not empty but there is no instance of that particular configuration file, no
@@ -3136,6 +3144,9 @@ class FASTGAHEPowerTrainConfigurator:
             return False
 
         if FASTGAHEPowerTrainConfigurator._cache[self._power_train_file].get("skip_test"):
+            FASTGAHEPowerTrainConfigurator._cache[self._power_train_file]["last_mod_time"] = (
+                pathlib.Path(self._power_train_file).lstat().st_mtime
+            )
             return True
 
         if not FASTGAHEPowerTrainConfigurator._cache[self._power_train_file].get(


### PR DESCRIPTION
The new entries in `_cache` store all static instance attribute values while preserving the original entries. This prevents unnecessary recalculation of these class variables and reduces the number of instance attributes that need to be initialized when reading from other scripts. The following plot demonstrates the list or dictionary entries of each PT file registered in `_cache`.
<img width="960" height="540" alt="未命名簡報" src="https://github.com/user-attachments/assets/ba2cd245-d3db-4474-8c0f-5f05adc69b13" />
