### PR TITLE
Fix: Powertrain Network Viewer Animation Issue  

### DIFF
--- a/integration_tests/quest_kodiak100/test_sizing_quest_kodiak100.py
+++ b/integration_tests/quest_kodiak100/test_sizing_quest_kodiak100.py
@@ -18,7 +18,6 @@ import plotly.graph_objects as go
 
 from utils.filter_residuals import filter_residuals
 
-
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
 WORKDIR_FOLDER_PATH = pth.join(pth.dirname(__file__), "workdir")


### PR DESCRIPTION
The previous connection-checking mechanism failed for multi-connection components when one connection was active and another was not. This issue is fixed by restructuring the check to determine whether the component itself is activated.