### PR TITLE
PEMFC Mass Transport Loss Coefficient Correction 

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -746,3 +746,10 @@ doi = {https://doi.org/10.1016/j.jpowsour.2004.09.027},
 url = {https://www.sciencedirect.com/science/article/pii/S0378775304010730},
 author = {J.J. Baschuk and Xianguo Li},
 }
+
+@book{ohayre:2016,
+  title={Fuel cell fundamentals},
+  author={O'hayre, Ryan and Cha, Suk-Won and Colella, Whitney and Prinz, Fritz B},
+  year={2016},
+  publisher={John Wiley \& Sons}
+}

--- a/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
+++ b/src/fastga_he/models/propulsion/assemblies/test_simple_assembly_gh2_pemfc.py
@@ -708,7 +708,7 @@ def test_performances_sizing_from_pt_with_sizing_options():
     assert problem.get_val(
         "constraints:propulsion:he_power_train:PEMFC_stack:pemfc_stack_1:effective_area",
         units="cm**2",
-    ) == pytest.approx(-1677.792, rel=1e-2)
+    ) == pytest.approx(-1718.488, rel=1e-2)
     assert problem.model.full.sizing.pemfc_stack_1.options["model_fidelity"] == "analytical"
     assert problem.model.full.sizing.h2_fuel_system_1.options["wing_related"]
     assert problem.model.full.sizing.h2_fuel_system_1.options["compact"]

--- a/src/fastga_he/models/propulsion/components/source/pemfc/components/perf_pemfc_polarization_curve.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/components/perf_pemfc_polarization_curve.py
@@ -205,8 +205,8 @@ class PerformancesPEMFCStackPolarizationCurveEmpirical(om.ExplicitComponent):
 class PerformancesPEMFCStackPolarizationCurveAnalytical(om.ExplicitComponent):
     """
     Computation of the single layer voltage of the PEMFC.This model is based on analytical i-v
-    curve equation. Details can be found in :cite:`Juschus:2021`. The hydrogen oxidation reaction
-    is assumed to produce liquid water following :cite:`baschuk:2005`.
+    curve equation. Details can be found in :cite:`juschus:2021` and :cite:`ohayre:2016`. The
+    hydrogen oxidation reaction is assumed to produce liquid water following :cite:`baschuk:2005`.
     """
 
     def initialize(self):

--- a/src/fastga_he/models/propulsion/components/source/pemfc/components/perf_pemfc_polarization_curve.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/components/perf_pemfc_polarization_curve.py
@@ -241,7 +241,7 @@ class PerformancesPEMFCStackPolarizationCurveAnalytical(om.ExplicitComponent):
         )
         self.options.declare(
             "mass_transport_loss_constant",
-            default=0.5,
+            default=0.1,
             desc="the constant result from mass transport in the PEMFC [V]",
         )
         self.options.declare(

--- a/src/fastga_he/models/propulsion/components/source/pemfc/unit_tests/test_pemfc.py
+++ b/src/fastga_he/models/propulsion/components/source/pemfc/unit_tests/test_pemfc.py
@@ -524,11 +524,6 @@ def test_pemfc_polarization_curve_analytical():
         units="atm",
         val=np.full(7, 1.2),
     )
-    ivc.add_output(
-        name="operating_temperature",
-        units="degC",
-        val=np.full(7, 50.0),
-    )
 
     # Run problem and check obtained value(s) is/(are) correct
     problem = run_system(
@@ -539,7 +534,7 @@ def test_pemfc_polarization_curve_analytical():
     )
 
     assert problem.get_val("single_layer_pemfc_voltage", units="V") == pytest.approx(
-        [0.79, 0.73, 0.68, 0.64, 0.59, 0.55, 0.50],
+        [0.816, 0.777, 0.75, 0.73, 0.711, 0.694, 0.678],
         rel=1e-2,
     )
 
@@ -809,7 +804,7 @@ def test_performances_pemfc_layer_voltage_analytical():
     )
 
     assert problem.get_val("single_layer_pemfc_voltage", units="V") == pytest.approx(
-        [0.79, 0.76, 0.73, 0.71, 0.68, 0.66, 0.64, 0.61, 0.59, 0.57],
+        [0.815, 0.793, 0.776, 0.762, 0.749, 0.738, 0.728, 0.719, 0.71, 0.701],
         rel=1e-2,
     )
 
@@ -914,7 +909,7 @@ def test_performances_pemfc_stack_analytical():
     )
 
     assert problem.get_val("single_layer_pemfc_voltage", units="V") == pytest.approx(
-        [0.79, 0.76, 0.73, 0.71, 0.68, 0.66, 0.64, 0.61, 0.59, 0.57],
+        [0.815, 0.793, 0.776, 0.762, 0.749, 0.738, 0.728, 0.719, 0.71, 0.701],
         rel=1e-2,
     )
 
@@ -927,7 +922,7 @@ def test_performances_pemfc_stack_analytical():
     )
 
     assert problem.get_val("efficiency") == pytest.approx(
-        [0.51, 0.49, 0.47, 0.45, 0.44, 0.42, 0.41, 0.394, 0.38, 0.366],
+        [0.523, 0.509, 0.498, 0.489, 0.481, 0.474, 0.467, 0.461, 0.455, 0.45],
         rel=1e-2,
     )
 


### PR DESCRIPTION
Due to an incorrect transport loss coefficient in the analytical PEMFC model, the polarization model could produce negative layer voltages, causing the simulation to crash. This issue has been resolved by replacing the coefficient with tabulated values from O’Hayre’s publication,  Fuel Cell Fundamentals.
<img width="606" height="337" alt="image" src="https://github.com/user-attachments/assets/a9dc12b6-5a9f-45ac-8a64-e3fcd2f36857" />
