### PR TITLE
Cost estimation update for electric power conversion components

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -754,7 +754,7 @@ author = {J.J. Baschuk and Xianguo Li},
   publisher={John Wiley \& Sons}
 }
 
-@artricle{menzi:2024,
+@article{menzi:2024,
   author={Menzi, David and Imperiali, Luc and Bürgisser, Elias and Ulmer, Martin and Huber, Jonas and Kolar, Johann W.},
   journal={IEEE Transactions on Transportation Electrification},
   title={Ultralightweight High-Efficiency Buck-Boost DC-DC Converters for Future eVTOL Aircraft With Hybrid Power Supply},
@@ -776,7 +776,7 @@ author = {J.J. Baschuk and Xianguo Li},
   keywords={Numerical models;Silicon;Heat sinks;Standards;Capacitors;Integrated circuit modeling;Power electronics},
   doi={10.1109/ECCE.2013.6646971}}
 
-@artricle{sathik:2018,
+@article{sathik:2018,
   author={Sathik, Mohamed Halick Mohamed and Prasanth, Sundarajan and Sasongko, Firman and Pou, Josep},
   journal={IEEE Aerospace and Electronic Systems Magazine},
   title={Lifetime estimation of off-the-shelf aerospace power converters},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -787,3 +787,10 @@ author = {J.J. Baschuk and Xianguo Li},
   keywords={Unmanned aerial vehicles;Insulated gate bipolar transistors;Maintenance engineering;Energy consumption;FAA;Multichip modules;Mathematical model;Hybrid electric vehicles;Aircraft propulsion},
   doi={10.1109/MAES.2018.180030}}
 
+@phdthesis{kremer:2022,
+  title={Study of multiplexed inverters for medium voltage drives},
+  author={Kremer, Vinicius},
+  year={2022},
+  school={Institut National Polytechnique de Toulouse-INPT}
+}
+

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -794,3 +794,11 @@ author = {J.J. Baschuk and Xianguo Li},
   school={Institut National Polytechnique de Toulouse-INPT}
 }
 
+@techreport{infineon:2021,
+  title       = {IPOSIM Lifetime Calculation Report},
+  author      = {{Infineon Technologies AG}},
+  institution = {Infineon Technologies AG},
+  number      = {51d2d008-b820-4628-b72d-79753e9fd13a},
+  year        = {2021},
+}
+

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -754,7 +754,7 @@ author = {J.J. Baschuk and Xianguo Li},
   publisher={John Wiley \& Sons}
 }
 
-@ARTICLE{menzi:2024,
+@artricle{menzi:2024,
   author={Menzi, David and Imperiali, Luc and Bürgisser, Elias and Ulmer, Martin and Huber, Jonas and Kolar, Johann W.},
   journal={IEEE Transactions on Transportation Electrification},
   title={Ultralightweight High-Efficiency Buck-Boost DC-DC Converters for Future eVTOL Aircraft With Hybrid Power Supply},
@@ -765,7 +765,7 @@ author = {J.J. Baschuk and Xianguo Li},
   keywords={DC-DC power converters;Batteries;Power system measurements;Density measurement;Aircraft;Hybrid power systems;Aircraft propulsion;Airborne;battery;buck-boost (BB);dc–dc converter;electric vertical take-off and landing (eVTOL);fuel cell (FC);gravimetric power density;hybrid power supply;non-isolated;ultralightweight},
   doi={10.1109/TTE.2024.3375026}}
 
-@INPROCEEDINGS{burkart:2013,
+@inproceedings{burkart:2013,
   author={Burkart, Ralph and Kolar, Johann W.},
   booktitle={2013 IEEE Energy Conversion Congress and Exposition},
   title={Component cost models for multi-objective optimizations of switched-mode power converters},
@@ -776,7 +776,7 @@ author = {J.J. Baschuk and Xianguo Li},
   keywords={Numerical models;Silicon;Heat sinks;Standards;Capacitors;Integrated circuit modeling;Power electronics},
   doi={10.1109/ECCE.2013.6646971}}
 
-@ARTICLE{sathik:2018,
+@artricle{sathik:2018,
   author={Sathik, Mohamed Halick Mohamed and Prasanth, Sundarajan and Sasongko, Firman and Pou, Josep},
   journal={IEEE Aerospace and Electronic Systems Magazine},
   title={Lifetime estimation of off-the-shelf aerospace power converters},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -753,3 +753,37 @@ author = {J.J. Baschuk and Xianguo Li},
   year={2016},
   publisher={John Wiley \& Sons}
 }
+
+@ARTICLE{menzi:2024,
+  author={Menzi, David and Imperiali, Luc and Bürgisser, Elias and Ulmer, Martin and Huber, Jonas and Kolar, Johann W.},
+  journal={IEEE Transactions on Transportation Electrification},
+  title={Ultralightweight High-Efficiency Buck-Boost DC-DC Converters for Future eVTOL Aircraft With Hybrid Power Supply},
+  year={2024},
+  volume={10},
+  number={4},
+  pages={10297-10313},
+  keywords={DC-DC power converters;Batteries;Power system measurements;Density measurement;Aircraft;Hybrid power systems;Aircraft propulsion;Airborne;battery;buck-boost (BB);dc–dc converter;electric vertical take-off and landing (eVTOL);fuel cell (FC);gravimetric power density;hybrid power supply;non-isolated;ultralightweight},
+  doi={10.1109/TTE.2024.3375026}}
+
+@INPROCEEDINGS{burkart:2013,
+  author={Burkart, Ralph and Kolar, Johann W.},
+  booktitle={2013 IEEE Energy Conversion Congress and Exposition},
+  title={Component cost models for multi-objective optimizations of switched-mode power converters},
+  year={2013},
+  volume={},
+  number={},
+  pages={2139-2146},
+  keywords={Numerical models;Silicon;Heat sinks;Standards;Capacitors;Integrated circuit modeling;Power electronics},
+  doi={10.1109/ECCE.2013.6646971}}
+
+@ARTICLE{sathik:2018,
+  author={Sathik, Mohamed Halick Mohamed and Prasanth, Sundarajan and Sasongko, Firman and Pou, Josep},
+  journal={IEEE Aerospace and Electronic Systems Magazine},
+  title={Lifetime estimation of off-the-shelf aerospace power converters},
+  year={2018},
+  volume={33},
+  number={12},
+  pages={26-38},
+  keywords={Unmanned aerial vehicles;Insulated gate bipolar transistors;Maintenance engineering;Energy consumption;FAA;Multichip modules;Mathematical model;Hybrid electric vehicles;Aircraft propulsion},
+  doi={10.1109/MAES.2018.180030}}
+

--- a/src/fastga_he/models/cost/unit_tests/test_cost.py
+++ b/src/fastga_he/models/cost/unit_tests/test_cost.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import os
 import pathlib
@@ -547,7 +547,7 @@ def test_production_cost_hydrogen():
     ) == pytest.approx(8120.33, rel=1e-3)
 
     assert problem.get_val("data:cost:production_cost_per_unit", units="USD") == pytest.approx(
-        376167.34, rel=1e-3
+        377127.48, rel=1e-3
     )
 
     problem.check_partials(compact_print=True)
@@ -589,11 +589,11 @@ def test_production_cost_hybrid_tbm_900():
     ) == pytest.approx(221207.71, rel=1e-3)
 
     assert problem.get_val("data:cost:production_cost_per_unit", units="USD") == pytest.approx(
-        4755318.92, rel=1e-3
+        4774515.71, rel=1e-3
     )
 
     assert problem.get_val("data:cost:msp_per_unit", units="USD") == pytest.approx(
-        5283687.68, rel=1e-3
+        5305017.45, rel=1e-3
     )
 
     problem.check_partials(compact_print=True)
@@ -964,7 +964,7 @@ def test_operational_cost_hydrogen():
 
     assert problem.get_val(
         "data:cost:operation:annual_cost_per_unit", units="USD/yr"
-    ) == pytest.approx(31543.8, rel=1e-3)
+    ) == pytest.approx(30047.64, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1041,7 +1041,7 @@ def test_operational_cost_hybrid_tbm_900():
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier:operational_cost",
         units="USD/yr",
-    ) == pytest.approx(166.5, rel=1e-3)
+    ) == pytest.approx(56.13, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1118,16 +1118,16 @@ def test_cost_pipistrel():
     ) == pytest.approx(13495.22, rel=1e-3)
 
     assert problem.get_val("data:cost:production_cost_per_unit", units="USD") == pytest.approx(
-        287239.8, rel=1e-3
+        290797, rel=1e-3
     )
 
     assert problem.get_val("data:cost:msp_per_unit", units="USD") == pytest.approx(
-        319155.37, rel=1e-3
+        323108.85, rel=1e-3
     )
 
     assert problem.get_val(
         "data:cost:operation:annual_cost_per_unit", units="USD/yr"
-    ) == pytest.approx(32520.05, rel=1e-3)
+    ) == pytest.approx(32176.6, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_cost.py
@@ -8,8 +8,11 @@ import openmdao.api as om
 
 class LCCDCDCConverterCost(om.ExplicitComponent):
     """
-    Computation of convertor purchase cost. Reference prices obtained from
-    https://www.mcico.com/truebluepower/converters?purchase_type=New+Outright%2CNew+Exchange.
+    Computation of convertor purchase cost based on a 3-level Buck-Boost architecture from
+    :cite:`menzi:2024`. This is estimated based on two IGBTs per switch, a 20% cost contribution
+    of the IGBTs to the total cost based on :cite:`burkart:2013`. The IGBT suggested pricing
+    (115 USD) is given by
+    https://www.mouser.fr/ProductDetail/Infineon-Technologies/FZ600R12KP4?qs=lxTgnyf4o0eNz5ooVj7tEA%3D%3D.
     """
 
     def initialize(self):
@@ -26,10 +29,11 @@ class LCCDCDCConverterCost(om.ExplicitComponent):
         self.add_input(
             name="data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
-            + ":dc_power_in_rating",
-            val=np.nan,
-            units="kW",
-            desc="Maximum power rating of the converter",
+            + ":number_of_switches",
+            val=4.0,
+            units="unitless",
+            desc="Number of switches in the converter based on the architecture (e.g., "
+            "4 for a 3-level Buck-Boost converter)",
         )
 
         self.add_output(
@@ -37,11 +41,12 @@ class LCCDCDCConverterCost(om.ExplicitComponent):
             + dc_dc_converter_id
             + ":purchase_cost",
             units="USD",
-            val=750.0,
+            val=4600.0,
             desc="Unit purchase cost of the converter",
         )
 
-        self.declare_partials(of="*", wrt="*", method="exact")
+    def setup_partials(self):
+        self.declare_partials(of="*", wrt="*", val=1150.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         dc_dc_converter_id = self.options["dc_dc_converter_id"]
@@ -51,32 +56,12 @@ class LCCDCDCConverterCost(om.ExplicitComponent):
             + dc_dc_converter_id
             + ":purchase_cost"
         ] = (
-            733.0
-            * np.log(
-                inputs[
-                    "data:propulsion:he_power_train:DC_DC_converter:"
-                    + dc_dc_converter_id
-                    + ":dc_power_in_rating"
-                ]
-            )
-            + 2295.0
-        )
-
-    def compute_partials(self, inputs, partials, discrete_inputs=None):
-        dc_dc_converter_id = self.options["dc_dc_converter_id"]
-
-        partials[
-            "data:propulsion:he_power_train:DC_DC_converter:"
-            + dc_dc_converter_id
-            + ":purchase_cost",
-            "data:propulsion:he_power_train:DC_DC_converter:"
-            + dc_dc_converter_id
-            + ":dc_power_in_rating",
-        ] = (
-            733.0
-            / inputs[
+            inputs[
                 "data:propulsion:he_power_train:DC_DC_converter:"
                 + dc_dc_converter_id
-                + ":dc_power_in_rating"
+                + ":number_of_switches"
             ]
+            * 115.0
+            * 2.0
+            / 0.2
         )

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_cost.py
@@ -1,8 +1,7 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
-import numpy as np
 import openmdao.api as om
 
 

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -41,7 +41,7 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             + dc_dc_converter_id
             + ":lifespan",
             units="h",
-            val=4.2e4,
+            val=3.4e4,
             desc="Expected lifetime of the DC_DC_converter, based on the lifespan of the IGBTs",
         )
 
@@ -50,7 +50,7 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             + dc_dc_converter_id
             + ":operational_cost",
             units="USD/yr",
-            val=31.02,
+            val=38.3,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -1,14 +1,17 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
 
+EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the IGBTs in hours, with a safety factor of 1.5
+
 
 class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
     """
-    Computation of convertor annual operational cost.
+    Computation of convertor annual operational cost. This is estimated based on the lifespan of
+    the IGBTs given by :cite:`sathik:2018`, which is indicated as the throttling component.
     """
 
     def initialize(self):
@@ -30,12 +33,10 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             units="USD",
         )
         self.add_input(
-            name="data:propulsion:he_power_train:DC_DC_converter:"
-            + dc_dc_converter_id
-            + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the DC_DC_converter, typically around 15 year",
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
         )
 
         self.add_output(
@@ -61,9 +62,8 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
                 + dc_dc_converter_id
                 + ":purchase_cost"
             ]
-            / inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
-            ]
+            * inputs["data:TLAR:flight_hours_per_year"]
+            / EXPECTED_LIFESPAN
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
@@ -76,26 +76,18 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":purchase_cost",
-        ] = (
-            1.0
-            / inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
-            ]
-        )
+        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
 
         partials[
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":operational_cost",
-            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan",
+            "data:TLAR:flight_hours_per_year",
         ] = (
-            -inputs[
+            inputs[
                 "data:propulsion:he_power_train:DC_DC_converter:"
                 + dc_dc_converter_id
                 + ":purchase_cost"
             ]
-            / inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
-            ]
-            ** 2.0
+            / EXPECTED_LIFESPAN
         )

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -47,6 +47,7 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             val=75.0,
         )
 
+    def setup_partials(self):
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -44,7 +44,7 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             + dc_dc_converter_id
             + ":operational_cost",
             units="USD/yr",
-            val=75.0,
+            val=31.02,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -5,8 +5,6 @@
 import numpy as np
 import openmdao.api as om
 
-EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the IGBTs in hours, with a safety factor of 1.5
-
 
 class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
     """
@@ -38,6 +36,14 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             units="h",
             desc="Expected number of hours flown per year",
         )
+        self.add_input(
+            name="data:propulsion:he_power_train:DC_DC_converter:"
+            + dc_dc_converter_id
+            + ":lifespan",
+            units="h",
+            val=4.2e4,
+            desc="Expected lifetime of the DC_DC_converter, based on the lifespan of the IGBTs",
+        )
 
         self.add_output(
             "data:propulsion:he_power_train:DC_DC_converter:"
@@ -53,22 +59,34 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         dc_dc_converter_id = self.options["dc_dc_converter_id"]
 
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:"
+            + dc_dc_converter_id
+            + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
+        ]
+
         outputs[
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":operational_cost"
-        ] = (
-            inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:"
-                + dc_dc_converter_id
-                + ":purchase_cost"
-            ]
-            * inputs["data:TLAR:flight_hours_per_year"]
-            / EXPECTED_LIFESPAN
-        )
+        ] = purchase_cost * flight_hours_per_year / lifespan
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         dc_dc_converter_id = self.options["dc_dc_converter_id"]
+
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:"
+            + dc_dc_converter_id
+            + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
+        ]
 
         partials[
             "data:propulsion:he_power_train:DC_DC_converter:"
@@ -77,18 +95,18 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":purchase_cost",
-        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
+        ] = flight_hours_per_year / lifespan
 
         partials[
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":operational_cost",
             "data:TLAR:flight_hours_per_year",
-        ] = (
-            inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:"
-                + dc_dc_converter_id
-                + ":purchase_cost"
-            ]
-            / EXPECTED_LIFESPAN
-        )
+        ] = purchase_cost / lifespan
+
+        partials[
+            "data:propulsion:he_power_train:DC_DC_converter:"
+            + dc_dc_converter_id
+            + ":operational_cost",
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan",
+        ] = -purchase_cost * flight_hours_per_year / lifespan**2.0

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/lcc_dc_dc_converter_operational_cost.py
@@ -69,6 +69,9 @@ class LCCDCDCConverterOperationalCost(om.ExplicitComponent):
             "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
         ]
 
+        # The operational cost is estimated by dividing the purchase cost by the IGBT lifetime
+        # expectancy. However, for annual flight hours below 2000 h, the component is unlikely to
+        # reach its end-of-life within the operational period of 15 years.
         outputs[
             "data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/pre_lca_prod_weight_per_fu.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/components/pre_lca_prod_weight_per_fu.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
@@ -36,12 +36,18 @@ class PreLCADCDCConverterProdWeightPerFU(om.ExplicitComponent):
             desc="Number of aircraft required for a functional unit",
         )
         self.add_input(
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
+        )
+        self.add_input(
             name="data:propulsion:he_power_train:DC_DC_converter:"
             + dc_dc_converter_id
             + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the DC_DC_converter, typically around 15 year",
+            units="h",
+            val=3.4e4,
+            desc="Expected lifetime of the DC_DC_converter, based on the lifespan of the IGBTs",
         )
         self.add_input(
             name="data:TLAR:aircraft_lifespan",
@@ -58,6 +64,9 @@ class PreLCADCDCConverterProdWeightPerFU(om.ExplicitComponent):
             val=1e-6,
             desc="Mass of the DC_DC_converter required for a functional unit",
         )
+
+    def setup_partials(self):
+        dc_dc_converter_id = self.options["dc_dc_converter_id"]
 
         self.declare_partials(
             of="*",
@@ -76,6 +85,7 @@ class PreLCADCDCConverterProdWeightPerFU(om.ExplicitComponent):
                 + dc_dc_converter_id
                 + ":lifespan",
                 "data:TLAR:aircraft_lifespan",
+                "data:TLAR:flight_hours_per_year",
             ],
             method="fd",
         )
@@ -83,41 +93,39 @@ class PreLCADCDCConverterProdWeightPerFU(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         dc_dc_converter_id = self.options["dc_dc_converter_id"]
 
+        mass = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass"
+        ]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
+        ]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+
         outputs[
             "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass_per_fu"
-        ] = (
-            inputs["data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass"]
-            * inputs["data:environmental_impact:aircraft_per_fu"]
-            * np.ceil(
-                inputs["data:TLAR:aircraft_lifespan"]
-                / inputs[
-                    "data:propulsion:he_power_train:DC_DC_converter:"
-                    + dc_dc_converter_id
-                    + ":lifespan"
-                ]
-            )
-        )
+        ] = mass * aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         dc_dc_converter_id = self.options["dc_dc_converter_id"]
 
+        mass = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass"
+        ]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs[
+            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
+        ]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+
         partials[
             "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass_per_fu",
             "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
-            ]
-        )
+        ] = aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
+
         partials[
             "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs[
-            "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":mass"
-        ] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:" + dc_dc_converter_id + ":lifespan"
-            ]
-        )
+        ] = mass * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
@@ -1409,9 +1409,9 @@ def test_cost():
     ivc = om.IndepVarComp()
 
     ivc.add_output(
-        "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:dc_power_in_rating",
-        364.0,
-        units="kW",
+        "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:number_of_switches",
+        4.0,
+        units="unitless",
     )
 
     problem = run_system(
@@ -1422,7 +1422,7 @@ def test_cost():
     assert problem.get_val(
         "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:purchase_cost",
         units="USD",
-    ) == pytest.approx(6617.61, rel=1e-2)
+    ) == pytest.approx(4600.0, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
@@ -1400,7 +1400,7 @@ def test_weight_per_fu():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:mass_per_fu", units="kg"
-    ) == pytest.approx(0.000172, rel=1e-3)
+    ) == pytest.approx(8.6e-5, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1444,6 +1444,6 @@ def test_operational_cost():
     assert problem.get_val(
         "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:operational_cost",
         units="USD/yr",
-    ) == pytest.approx(31.02, rel=1e-2)
+    ) == pytest.approx(38.3, rel=1e-2)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
@@ -1432,7 +1432,7 @@ def test_operational_cost():
 
     ivc.add_output(
         "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:purchase_cost",
-        6617.61,
+        4600.0,
         units="USD",
     )
 
@@ -1444,6 +1444,6 @@ def test_operational_cost():
     assert problem.get_val(
         "data:propulsion:he_power_train:DC_DC_converter:dc_dc_converter_1:operational_cost",
         units="USD/yr",
-    ) == pytest.approx(441.17, rel=1e-2)
+    ) == pytest.approx(31.02, rel=1e-2)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/dc_dc_converter/unit_tests/test_dc_dc_converter.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import openmdao.api as om
 import pytest

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
@@ -2,7 +2,6 @@
 # Electric Aircraft.
 # Copyright (C) 2025 ISAE-SUPAERO
 
-import numpy as np
 import openmdao.api as om
 
 

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
@@ -27,16 +27,16 @@ class LCCInverterCost(om.ExplicitComponent):
 
         self.add_input(
             name="data:propulsion:he_power_train:inverter:" + inverter_id + ":number_of_switches",
-            val=18.0,
+            val=6.0,
             units="unitless",
             desc="Number of switches in the inverter based on the architecture (e.g., "
-            "18 for a 3-level NPC inverter)",
+            "6 for a 3-level NPC inverter)",
         )
 
         self.add_output(
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost",
             units="USD",
-            val=10350.0,
+            val=3450.0,
             desc="Unit purchase cost of the inverter",
         )
 

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
@@ -26,9 +26,7 @@ class LCCInverterCost(om.ExplicitComponent):
         inverter_id = self.options["inverter_id"]
 
         self.add_input(
-            name="data:propulsion:he_power_train:DC_DC_converter:"
-            + inverter_id
-            + ":number_of_switches",
+            name="data:propulsion:he_power_train:inverter:" + inverter_id + ":number_of_switches",
             val=18.0,
             units="unitless",
             desc="Number of switches in the inverter based on the architecture (e.g., "
@@ -51,9 +49,7 @@ class LCCInverterCost(om.ExplicitComponent):
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"] = (
             115.0
             * inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:"
-                + inverter_id
-                + ":number_of_switches"
+                "data:propulsion:he_power_train:inverter:" + inverter_id + ":number_of_switches"
             ]
             / 0.2
         )

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
@@ -8,10 +8,11 @@ import openmdao.api as om
 
 class LCCInverterCost(om.ExplicitComponent):
     """
-    Computation of the inverter purchase cost. Based on the retail price provided by
-    https://www.mcico.com/truebluepower/inverters?purchase_type=New+Outright%2CNew+Exchange and
-    several high power inverters from
-    https://emrax.com/wp-content/uploads/2020/03/recommended_controllers_for_emrax_motors_5.3.xlsx.
+    Computation of inverter purchase cost based on a 3-level NPC architecture from
+    :cite:`kremer:2022`. This is estimated based on 6 IGBTs per level, a 20% cost contribution
+    of the IGBTs to the total cost based on :cite:`burkart:2013`. The IGBT suggested pricing
+    (115 USD) is given by
+    https://www.mouser.fr/ProductDetail/Infineon-Technologies/FZ600R12KP4?qs=lxTgnyf4o0eNz5ooVj7tEA%3D%3D.
     """
 
     def initialize(self):
@@ -26,42 +27,33 @@ class LCCInverterCost(om.ExplicitComponent):
         inverter_id = self.options["inverter_id"]
 
         self.add_input(
-            name="data:propulsion:he_power_train:inverter:" + inverter_id + ":ac_power_out_rating",
-            units="kW",
-            val=np.nan,
-            desc="Max power at the output side of the inverter",
+            name="data:propulsion:he_power_train:DC_DC_converter:"
+            + inverter_id
+            + ":number_of_switches",
+            val=18.0,
+            units="unitless",
+            desc="Number of switches in the inverter based on the architecture (e.g., "
+            "18 for a 3-level NPC inverter)",
         )
 
         self.add_output(
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost",
             units="USD",
-            val=3500.0,
+            val=10350.0,
             desc="Unit purchase cost of the inverter",
         )
 
-        self.declare_partials(of="*", wrt="*", method="exact")
+        self.declare_partials(of="*", wrt="*", val=575.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         inverter_id = self.options["inverter_id"]
 
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"] = (
-            4666.0
+            115.0
             * inputs[
-                "data:propulsion:he_power_train:inverter:" + inverter_id + ":ac_power_out_rating"
+                "data:propulsion:he_power_train:DC_DC_converter:"
+                + inverter_id
+                + ":number_of_switches"
             ]
-            ** 0.0928
-        )
-
-    def compute_partials(self, inputs, partials, discrete_inputs=None):
-        inverter_id = self.options["inverter_id"]
-
-        partials[
-            "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost",
-            "data:propulsion:he_power_train:inverter:" + inverter_id + ":ac_power_out_rating",
-        ] = (
-            433.0048
-            * inputs[
-                "data:propulsion:he_power_train:inverter:" + inverter_id + ":ac_power_out_rating"
-            ]
-            ** -0.9072
+            / 0.2
         )

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_cost.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import openmdao.api as om
 
@@ -42,6 +42,7 @@ class LCCInverterCost(om.ExplicitComponent):
             desc="Unit purchase cost of the inverter",
         )
 
+    def setup_partials(self):
         self.declare_partials(of="*", wrt="*", val=575.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -43,6 +43,7 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
             val=350.0,
         )
 
+    def setup_partials(self):
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -37,14 +37,14 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
         self.add_input(
             name="data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
             units="h",
-            val=4.2e4,
+            val=3.4e4,
             desc="Expected lifetime of the inverter, based on the lifespan of the IGBTs",
         )
 
         self.add_output(
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
             units="USD/yr",
-            val=23.26,
+            val=28.7,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -1,14 +1,17 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
 
+EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the IGBTs in hours, with a safety factor of 1.5
+
 
 class LCCInverterOperationalCost(om.ExplicitComponent):
     """
-    Computation of the inverter annual operational cost.
+    Computation of the inverter annual operational cost. This is estimated based on the lifespan of
+    the IGBTs given by :cite:`sathik:2018`, which is indicated as the throttling component.
     """
 
     def initialize(self):
@@ -28,10 +31,10 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
             val=np.nan,
         )
         self.add_input(
-            name="data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the inverter, typically around 15 year",
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
         )
 
         self.add_output(
@@ -47,7 +50,8 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
 
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost"] = (
             inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"]
-            / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+            * inputs["data:TLAR:flight_hours_per_year"]
+            / EXPECTED_LIFESPAN
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
@@ -56,12 +60,12 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost",
-        ] = 1.0 / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
 
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
-            "data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
+            "data:TLAR:flight_hours_per_year",
         ] = (
-            -inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"]
-            / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"] ** 2.0
+            inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"]
+            / EXPECTED_LIFESPAN
         )

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -40,7 +40,7 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
         self.add_output(
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
             units="USD/yr",
-            val=350.0,
+            val=23.26,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -5,8 +5,6 @@
 import numpy as np
 import openmdao.api as om
 
-EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the IGBTs in hours, with a safety factor of 1.5
-
 
 class LCCInverterOperationalCost(om.ExplicitComponent):
     """
@@ -36,6 +34,12 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
             units="h",
             desc="Expected number of hours flown per year",
         )
+        self.add_input(
+            name="data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
+            units="h",
+            val=4.2e4,
+            desc="Expected lifetime of the inverter, based on the lifespan of the IGBTs",
+        )
 
         self.add_output(
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
@@ -49,24 +53,36 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         inverter_id = self.options["inverter_id"]
 
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost"] = (
-            inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"]
-            * inputs["data:TLAR:flight_hours_per_year"]
-            / EXPECTED_LIFESPAN
+            purchase_cost * flight_hours_per_year / lifespan
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         inverter_id = self.options["inverter_id"]
 
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost",
-        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
+        ] = flight_hours_per_year / lifespan
 
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
             "data:TLAR:flight_hours_per_year",
-        ] = (
-            inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":purchase_cost"]
-            / EXPECTED_LIFESPAN
-        )
+        ] = purchase_cost / lifespan
+
+        partials[
+            "data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost",
+            "data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
+        ] = -purchase_cost * flight_hours_per_year / lifespan**2.0

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/lcc_inverter_operational_cost.py
@@ -59,6 +59,9 @@ class LCCInverterOperationalCost(om.ExplicitComponent):
         flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
         lifespan = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
 
+        # The operational cost is estimated by dividing the purchase cost by the IGBT lifetime
+        # expectancy. However, for annual flight hours below 2000 h, the component is unlikely to
+        # reach its end-of-life within the operational period of 15 years.
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":operational_cost"] = (
             purchase_cost * flight_hours_per_year / lifespan
         )

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/pre_lca_prod_weight_per_fu.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/pre_lca_prod_weight_per_fu.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
@@ -36,10 +36,16 @@ class PreLCAInverterProdWeightPerFU(om.ExplicitComponent):
             desc="Number of aircraft required for a functional unit",
         )
         self.add_input(
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
+        )
+        self.add_input(
             name="data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the inverter, typically around 15 year",
+            units="h",
+            val=3.4e4,
+            desc="Expected lifetime of the inverter, based on the lifespan of the IGBTs",
         )
         self.add_input(
             name="data:TLAR:aircraft_lifespan",
@@ -54,6 +60,9 @@ class PreLCAInverterProdWeightPerFU(om.ExplicitComponent):
             val=1e-6,
             desc="Mass of the inverter required for a functional unit",
         )
+
+    def setup_partials(self):
+        inverter_id = self.options["inverter_id"]
 
         self.declare_partials(
             of="*",
@@ -70,6 +79,7 @@ class PreLCAInverterProdWeightPerFU(om.ExplicitComponent):
             wrt=[
                 "data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan",
                 "data:TLAR:aircraft_lifespan",
+                "data:TLAR:flight_hours_per_year",
             ],
             method="fd",
         )
@@ -77,29 +87,31 @@ class PreLCAInverterProdWeightPerFU(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         inverter_id = self.options["inverter_id"]
 
+        mass = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":mass"]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+
         outputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":mass_per_fu"] = (
-            inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":mass"]
-            * inputs["data:environmental_impact:aircraft_per_fu"]
-            * np.ceil(
-                inputs["data:TLAR:aircraft_lifespan"]
-                / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
-            )
+            mass * aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         inverter_id = self.options["inverter_id"]
 
+        mass = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":mass"]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass_per_fu",
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
-        )
+        ] = mass * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
+
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":mass"] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs["data:propulsion:he_power_train:inverter:" + inverter_id + ":lifespan"]
-        )
+        ] = aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/components/pre_lca_prod_weight_per_fu.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/components/pre_lca_prod_weight_per_fu.py
@@ -109,9 +109,9 @@ class PreLCAInverterProdWeightPerFU(om.ExplicitComponent):
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass_per_fu",
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass",
-        ] = mass * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
+        ] = aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
 
         partials[
             "data:propulsion:he_power_train:inverter:" + inverter_id + ":mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
+        ] = mass * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1561,7 +1561,7 @@ def test_cost():
     ivc = om.IndepVarComp()
     ivc.add_output(
         name="data:propulsion:he_power_train:inverter:inverter_1:number_of_switches",
-        val=18.0,
+        val=6.0,
         units="unitless",
     )
 
@@ -1572,7 +1572,7 @@ def test_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:purchase_cost", units="USD"
-    ) == pytest.approx(10350.0, rel=1e-3)
+    ) == pytest.approx(3450.0, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1581,7 +1581,7 @@ def test_operational_cost():
     ivc = om.IndepVarComp()
     ivc.add_output(
         name="data:propulsion:he_power_train:inverter:inverter_1:purchase_cost",
-        val=10350.0,
+        val=3450.0,
         units="USD",
     )
 
@@ -1592,6 +1592,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(69.79, rel=1e-3)
+    ) == pytest.approx(23.26, rel=1e-3)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1560,9 +1560,9 @@ def test_weight_per_fu():
 def test_cost():
     ivc = om.IndepVarComp()
     ivc.add_output(
-        name="data:propulsion:he_power_train:inverter:inverter_1:ac_power_out_rating",
-        val=200.0,
-        units="kW",
+        name="data:propulsion:he_power_train:inverter:inverter_1:number_of_switches",
+        val=18.0,
+        units="unitless",
     )
 
     problem = run_system(
@@ -1572,7 +1572,7 @@ def test_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:purchase_cost", units="USD"
-    ) == pytest.approx(7629.22, rel=1e-3)
+    ) == pytest.approx(10350.0, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1552,7 +1552,7 @@ def test_weight_per_fu():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:mass_per_fu", units="kg"
-    ) == pytest.approx(8.564e-05, rel=1e-3)
+    ) == pytest.approx(4.28e-05, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1592,6 +1592,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(23.26, rel=1e-3)
+    ) == pytest.approx(28.7, rel=1e-3)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1592,6 +1592,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(28.7, rel=1e-3)
+    ) == pytest.approx(28.74, rel=1e-3)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
+++ b/src/fastga_he/models/propulsion/components/connectors/inverter/unit_tests/test_inverter.py
@@ -1581,7 +1581,7 @@ def test_operational_cost():
     ivc = om.IndepVarComp()
     ivc.add_output(
         name="data:propulsion:he_power_train:inverter:inverter_1:purchase_cost",
-        val=18391.45,
+        val=10350.0,
         units="USD",
     )
 
@@ -1592,6 +1592,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:inverter:inverter_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(1226.096, rel=1e-3)
+    ) == pytest.approx(69.79, rel=1e-3)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
@@ -1,8 +1,7 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
-import numpy as np
 import openmdao.api as om
 
 

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
@@ -8,8 +8,10 @@ import openmdao.api as om
 
 class LCCRectifierCost(om.ExplicitComponent):
     """
-    Computation of the rectifier purchase cost. The retail price is provided by
-    https://www.ato.com/plating-rectifier.
+    Computation of the rectifier purchase cost based on three-phase full bridge architecture.
+     This is estimated based on two diodes per branch, a 20% cost contribution
+    of the main electronics to the total cost based on :cite:`burkart:2013`. The diode suggested
+    pricing (90 USD) is given by https://www.poweralia.com/d75-1400-12-8029.
     """
 
     def initialize(self):
@@ -24,32 +26,34 @@ class LCCRectifierCost(om.ExplicitComponent):
         rectifier_id = self.options["rectifier_id"]
 
         self.add_input(
-            name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":current_ac_caliber",
-            units="A",
-            val=np.nan,
-            desc="Caliber RMS current flowing through one arm of the rectifier, used for sizing",
+            name="data:propulsion:he_power_train:DC_DC_converter:"
+            + rectifier_id
+            + ":number_of_diodes",
+            val=6.0,
+            units="unitless",
+            desc="Number of diodes in the rectifier based on the architecture (e.g., "
+            "6 for a three-phase full bridge rectifier)",
         )
 
         self.add_output(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost",
             units="USD",
-            val=3500.0,
+            val=2700.0,
             desc="Unit purchase cost of the rectifier",
         )
 
-        self.declare_partials(
-            of="*",
-            wrt="*",
-            val=1.72,
-        )
+    def setup_partials(self):
+        self.declare_partials(of="*", wrt="*", val=450.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         rectifier_id = self.options["rectifier_id"]
 
         outputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"] = (
-            1.72
+            90.0
             * inputs[
-                "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":current_ac_caliber"
+                "data:propulsion:he_power_train:DC_DC_converter:"
+                + rectifier_id
+                + ":number_of_diodes"
             ]
-            + 2034.0
+            / 0.2
         )

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
@@ -9,8 +9,9 @@ class LCCRectifierCost(om.ExplicitComponent):
     """
     Computation of the rectifier purchase cost based on three-phase full bridge architecture.
      This is estimated based on two diodes per branch, a 20% cost contribution
-    of the main electronics to the total cost based on :cite:`burkart:2013`. The diode suggested
-    pricing (90 USD) is given by https://www.poweralia.com/d75-1400-12-8029.
+    of the main electronics to the total cost based on :cite:`burkart:2013`. The IGBT suggested pricing
+    (115 USD) is given by
+    https://www.mouser.fr/ProductDetail/Infineon-Technologies/FZ600R12KP4?qs=lxTgnyf4o0eNz5ooVj7tEA%3D%3D.
     """
 
     def initialize(self):
@@ -35,18 +36,18 @@ class LCCRectifierCost(om.ExplicitComponent):
         self.add_output(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost",
             units="USD",
-            val=2700.0,
+            val=3450.0,
             desc="Unit purchase cost of the rectifier",
         )
 
     def setup_partials(self):
-        self.declare_partials(of="*", wrt="*", val=450.0)
+        self.declare_partials(of="*", wrt="*", val=575.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         rectifier_id = self.options["rectifier_id"]
 
         outputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"] = (
-            90.0
+            115.0
             * inputs[
                 "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":number_of_diodes"
             ]

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_cost.py
@@ -25,9 +25,7 @@ class LCCRectifierCost(om.ExplicitComponent):
         rectifier_id = self.options["rectifier_id"]
 
         self.add_input(
-            name="data:propulsion:he_power_train:DC_DC_converter:"
-            + rectifier_id
-            + ":number_of_diodes",
+            name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":number_of_diodes",
             val=6.0,
             units="unitless",
             desc="Number of diodes in the rectifier based on the architecture (e.g., "
@@ -50,9 +48,7 @@ class LCCRectifierCost(om.ExplicitComponent):
         outputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"] = (
             90.0
             * inputs[
-                "data:propulsion:he_power_train:DC_DC_converter:"
-                + rectifier_id
-                + ":number_of_diodes"
+                "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":number_of_diodes"
             ]
             / 0.2
         )

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
@@ -61,6 +61,9 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
         flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
         lifespan = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
 
+        # The operational cost is estimated by dividing the purchase cost by the IGBT lifetime
+        # expectancy. However, for annual flight hours below 2000 h, the component is unlikely to
+        # reach its end-of-life within the operational period of 15 years.
         outputs[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost"
         ] = purchase_cost * flight_hours_per_year / lifespan

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
@@ -39,14 +39,14 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
         self.add_input(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
             units="h",
-            val=4.2e4,
+            val=3.4e4,
             desc="Expected lifetime of the rectifier, based on the lifespan of the IGBTs",
         )
 
         self.add_output(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
             units="USD/yr",
-            val=23.26,
+            val=28.7,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
@@ -1,14 +1,19 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
 
+EXPECTED_LIFESPAN = 1.26e4  # Expected lifespan of the diode in hours, with a safety factor of 1.5
+
 
 class LCCRectifierOperationalCost(om.ExplicitComponent):
     """
-    Computation of the annual operational cost of rectifier.
+    Computation of the annual operational cost of rectifier. The diodes are considered as the
+    throttle components in the system. Thw estimated rectifier life expectancy is based on the
+    lifespan of the IGBTs given by :cite:`sathik:2018` and a reduction factor of 0.3 based on the
+    result from :cite:`infineon:2021`.
     """
 
     def initialize(self):
@@ -29,10 +34,10 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
             desc="Maximum RMS current flowing through one arm of the rectifier",
         )
         self.add_input(
-            name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the rectifier, typically around 15 year",
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
         )
 
         self.add_output(
@@ -41,6 +46,7 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
             val=350.0,
         )
 
+    def setup_partials(self):
         self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
@@ -50,7 +56,8 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost"
         ] = (
             inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"]
-            / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+            * inputs["data:TLAR:flight_hours_per_year"]
+            / EXPECTED_LIFESPAN
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
@@ -59,13 +66,12 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost",
-        ] = 1.0 / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
 
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
-            "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
+            "data:TLAR:flight_hours_per_year",
         ] = (
-            -inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"]
-            / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
-            ** 2.0
+            inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"]
+            / EXPECTED_LIFESPAN
         )

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
@@ -5,15 +5,14 @@
 import numpy as np
 import openmdao.api as om
 
-EXPECTED_LIFESPAN = 1.26e4  # Expected lifespan of the diode in hours, with a safety factor of 1.5
+EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the diode in hours,
 
 
 class LCCRectifierOperationalCost(om.ExplicitComponent):
     """
     Computation of the annual operational cost of rectifier. The diodes are considered as the
-    throttle components in the system. Thw estimated rectifier life expectancy is based on the
-    lifespan of the IGBTs given by :cite:`sathik:2018` and a reduction factor of 0.3 based on the
-    result from :cite:`infineon:2021`.
+    throttle components in the system. The estimated rectifier life expectancy is based on the
+    lifespan of the IGBTs given by :cite:`sathik:2018` .
     """
 
     def initialize(self):
@@ -43,7 +42,7 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
         self.add_output(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
             units="USD/yr",
-            val=350.0,
+            val=23.26,
         )
 
     def setup_partials(self):

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/lcc_rectifier_operational_cost.py
@@ -5,8 +5,6 @@
 import numpy as np
 import openmdao.api as om
 
-EXPECTED_LIFESPAN = 4.2e4  # Expected lifespan of the diode in hours,
-
 
 class LCCRectifierOperationalCost(om.ExplicitComponent):
     """
@@ -38,6 +36,12 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
             units="h",
             desc="Expected number of hours flown per year",
         )
+        self.add_input(
+            name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
+            units="h",
+            val=4.2e4,
+            desc="Expected lifetime of the rectifier, based on the lifespan of the IGBTs",
+        )
 
         self.add_output(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
@@ -51,26 +55,36 @@ class LCCRectifierOperationalCost(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         rectifier_id = self.options["rectifier_id"]
 
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+
         outputs[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost"
-        ] = (
-            inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"]
-            * inputs["data:TLAR:flight_hours_per_year"]
-            / EXPECTED_LIFESPAN
-        )
+        ] = purchase_cost * flight_hours_per_year / lifespan
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         rectifier_id = self.options["rectifier_id"]
 
+        purchase_cost = inputs[
+            "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"
+        ]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+        lifespan = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost",
-        ] = inputs["data:TLAR:flight_hours_per_year"] / EXPECTED_LIFESPAN
+        ] = flight_hours_per_year / lifespan
 
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
             "data:TLAR:flight_hours_per_year",
-        ] = (
-            inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":purchase_cost"]
-            / EXPECTED_LIFESPAN
-        )
+        ] = purchase_cost / lifespan
+
+        partials[
+            "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":operational_cost",
+            "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
+        ] = -purchase_cost * flight_hours_per_year / lifespan**2.0

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/components/pre_lca_prod_weight_per_fu.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/components/pre_lca_prod_weight_per_fu.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import numpy as np
 import openmdao.api as om
@@ -36,10 +36,16 @@ class PreLCARectifierProdWeightPerFU(om.ExplicitComponent):
             desc="Number of aircraft required for a functional unit",
         )
         self.add_input(
+            name="data:TLAR:flight_hours_per_year",
+            val=283.2,
+            units="h",
+            desc="Expected number of hours flown per year",
+        )
+        self.add_input(
             name="data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
-            units="yr",
-            val=15.0,
-            desc="Expected lifetime of the rectifier, typically around 15 year",
+            units="h",
+            val=3.4e4,
+            desc="Expected lifetime of the rectifier, based on the lifespan of the IGBTs",
         )
         self.add_input(
             name="data:TLAR:aircraft_lifespan",
@@ -55,6 +61,9 @@ class PreLCARectifierProdWeightPerFU(om.ExplicitComponent):
             desc="Weight of the rectifier required for a functional unit",
         )
 
+    def setup_partials(self):
+        rectifier_id = self.options["rectifier_id"]
+
         self.declare_partials(
             of="*",
             wrt=[
@@ -63,11 +72,14 @@ class PreLCARectifierProdWeightPerFU(om.ExplicitComponent):
             ],
             method="exact",
         )
+        # I unfortunately have to put fd since there is no analytical expression for the
+        # derivative of ceil and openmdao does not like when a nil derivative is declared
         self.declare_partials(
             of="*",
             wrt=[
                 "data:TLAR:aircraft_lifespan",
                 "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan",
+                "data:TLAR:flight_hours_per_year",
             ],
             method="fd",
         )
@@ -75,29 +87,31 @@ class PreLCARectifierProdWeightPerFU(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         rectifier_id = self.options["rectifier_id"]
 
+        mass = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass"]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+        lifespan = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+
         outputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass_per_fu"] = (
-            inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass"]
-            * inputs["data:environmental_impact:aircraft_per_fu"]
-            * np.ceil(
-                inputs["data:TLAR:aircraft_lifespan"]
-                / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
-            )
+            mass * aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
         )
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         rectifier_id = self.options["rectifier_id"]
 
+        mass = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass"]
+        aircraft_per_fu = inputs["data:environmental_impact:aircraft_per_fu"]
+        aircraft_lifespan = inputs["data:TLAR:aircraft_lifespan"]
+        lifespan = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
+        flight_hours_per_year = inputs["data:TLAR:flight_hours_per_year"]
+
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass_per_fu",
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass",
-        ] = inputs["data:environmental_impact:aircraft_per_fu"] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
-        )
+        ] = aircraft_per_fu * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)
+
         partials[
             "data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass_per_fu",
             "data:environmental_impact:aircraft_per_fu",
-        ] = inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":mass"] * np.ceil(
-            inputs["data:TLAR:aircraft_lifespan"]
-            / inputs["data:propulsion:he_power_train:rectifier:" + rectifier_id + ":lifespan"]
-        )
+        ] = mass * np.ceil(aircraft_lifespan * flight_hours_per_year / lifespan)

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
@@ -1282,7 +1282,7 @@ def test_weight_per_fu():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:mass_per_fu", units="kg"
-    ) == pytest.approx(3.436e-05, rel=1e-3)
+    ) == pytest.approx(1.718e-05, rel=1e-3)
 
     problem.check_partials(compact_print=True)
 
@@ -1322,6 +1322,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(23.26, rel=1e-2)
+    ) == pytest.approx(28.7, rel=1e-2)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
@@ -1290,9 +1290,9 @@ def test_weight_per_fu():
 def test_cost():
     ivc = om.IndepVarComp()
     ivc.add_output(
-        "data:propulsion:he_power_train:rectifier:rectifier_1:current_ac_caliber",
-        units="A",
-        val=150.0,
+        "data:propulsion:he_power_train:rectifier:rectifier_1:number_of_diodes",
+        units="unitless",
+        val=6.0,
     )
 
     problem = run_system(
@@ -1302,7 +1302,7 @@ def test_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:purchase_cost", units="USD"
-    ) == pytest.approx(2292.0, rel=1e-2)
+    ) == pytest.approx(2700.0, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
@@ -1302,7 +1302,7 @@ def test_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:purchase_cost", units="USD"
-    ) == pytest.approx(2700.0, rel=1e-2)
+    ) == pytest.approx(3450.0, rel=1e-2)
 
     problem.check_partials(compact_print=True)
 
@@ -1312,7 +1312,7 @@ def test_operational_cost():
     ivc.add_output(
         "data:propulsion:he_power_train:rectifier:rectifier_1:purchase_cost",
         units="USD",
-        val=2700.0,
+        val=3450.0,
     )
 
     problem = run_system(
@@ -1322,6 +1322,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(60.7, rel=1e-2)
+    ) == pytest.approx(23.26, rel=1e-2)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
@@ -1,6 +1,6 @@
 # This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
 # Electric Aircraft.
-# Copyright (C) 2025 ISAE-SUPAERO
+# Copyright (C) 2026 ISAE-SUPAERO
 
 import openmdao.api as om
 import pytest
@@ -1312,7 +1312,7 @@ def test_operational_cost():
     ivc.add_output(
         "data:propulsion:he_power_train:rectifier:rectifier_1:purchase_cost",
         units="USD",
-        val=2292.0,
+        val=2700.0,
     )
 
     problem = run_system(
@@ -1322,6 +1322,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(152.8, rel=1e-2)
+    ) == pytest.approx(60.7, rel=1e-2)
 
     problem.check_partials(compact_print=True)

--- a/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
+++ b/src/fastga_he/models/propulsion/components/connectors/rectifier/unit_tests/test_rectifier.py
@@ -1322,6 +1322,6 @@ def test_operational_cost():
 
     assert problem.get_val(
         "data:propulsion:he_power_train:rectifier:rectifier_1:operational_cost", units="USD/yr"
-    ) == pytest.approx(28.7, rel=1e-2)
+    ) == pytest.approx(28.74, rel=1e-2)
 
     problem.check_partials(compact_print=True)


### PR DESCRIPTION
This PR updates the off-the-shelf cost and annual operation split models for the DC-DC converter, inverter, and rectifier. The new estimation method is based on the component architecture,  IGBT lifespan expectancy, and the IGBT module retail pricing.